### PR TITLE
Feature: 브랜드, 스타일포인트, 카테고리 관련 기능 추가

### DIFF
--- a/src/main/java/com/thekey/stylekeyserver/StyleKeyServerApplication.java
+++ b/src/main/java/com/thekey/stylekeyserver/StyleKeyServerApplication.java
@@ -2,7 +2,9 @@ package com.thekey.stylekeyserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class StyleKeyServerApplication {
 

--- a/src/main/java/com/thekey/stylekeyserver/base/BaseTimeEntity.java
+++ b/src/main/java/com/thekey/stylekeyserver/base/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.thekey.stylekeyserver.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name ="created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/thekey/stylekeyserver/brand/controller/BrandAdminController.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/controller/BrandAdminController.java
@@ -1,0 +1,85 @@
+package com.thekey.stylekeyserver.brand.controller;
+
+import com.thekey.stylekeyserver.brand.domain.Brand;
+import com.thekey.stylekeyserver.brand.dto.BrandDto;
+import com.thekey.stylekeyserver.brand.service.BrandAdminService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Brand", description = "Brand API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/brands")
+public class BrandAdminController {
+
+    private final BrandAdminService brandAdminService;
+
+    @PostMapping
+    @Operation(summary = "Create Brand", description = "브랜드 정보 등록")
+    public ResponseEntity<BrandDto> createBrand(@RequestBody BrandDto requestDto) {
+        Optional<Brand> optional = Optional.ofNullable(brandAdminService.create(requestDto));
+
+        return optional.map(createdBrand -> {
+            BrandDto response = brandAdminService.convertToDto(createdBrand);
+            return ResponseEntity.ok(response);
+        }).orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Read One Brand", description = "브랜드 정보 단건 조회")
+    public ResponseEntity<BrandDto> getBrand(@PathVariable Long id) {
+        Optional<Brand> optional = Optional.ofNullable(brandAdminService.findById(id));
+
+        return optional.map(brand -> {
+            BrandDto responseDto = brandAdminService.convertToDto(brand);
+            return ResponseEntity.ok(responseDto);
+        }).orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping
+    @Operation(summary = "Read All Brands", description = "브랜드 정보 전체 조회")
+    public ResponseEntity<List<Brand>> getBrands() {
+        List<Brand> brands = brandAdminService.findAll();
+
+        return Optional.of(brands)
+                .filter(list -> !list.isEmpty())
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.status(HttpStatus.NO_CONTENT).body(brands));
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Update Brand", description = "브랜드 정보 수정")
+    public ResponseEntity<BrandDto> updateBrand(@PathVariable Long id,
+                                                @RequestBody BrandDto requestDto) {
+        if (id == null) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        Optional<Brand> optional = Optional.ofNullable(brandAdminService.update(id, requestDto));
+        return optional.map(brand -> {
+            BrandDto response = brandAdminService.convertToDto(brand);
+            return ResponseEntity.ok(response);
+        }).orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Delete Brand", description = "브랜드 정보 삭제")
+    public ResponseEntity<Void> deleteBrand(@PathVariable Long id) {
+        brandAdminService.delete(id);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/com/thekey/stylekeyserver/brand/domain/Brand.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/domain/Brand.java
@@ -1,0 +1,67 @@
+package com.thekey.stylekeyserver.brand.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Brand {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "brand_title")
+    private String title;
+
+    @Column(name = "brand_title_eng")
+    private String title_eng;
+
+    @Column(name = "brand_description")
+    private String description;
+
+    @Column(name = "brand_site_url")
+    private String site_url;
+
+    @Column(name = "brand_image")
+    private String image;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stylepoint_id")
+    @JsonIgnore
+    private StylePoint stylePoint;
+
+    @Builder
+    public Brand(String title, String title_eng, String description, String site_url, String image,
+                 StylePoint stylePoint) {
+        this.title = title;
+        this.title_eng = title_eng;
+        this.description = description;
+        this.site_url = site_url;
+        this.image = image;
+        this.stylePoint = stylePoint;
+    }
+
+    public void update(String title, String title_eng, String description, String site_url, String image,
+                       StylePoint stylePoint) {
+        this.title = title;
+        this.title_eng = title_eng;
+        this.description = description;
+        this.site_url = site_url;
+        this.image = image;
+        this.stylePoint = stylePoint;
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/brand/dto/BrandDto.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/dto/BrandDto.java
@@ -1,0 +1,58 @@
+package com.thekey.stylekeyserver.brand.dto;
+
+import com.thekey.stylekeyserver.brand.domain.Brand;
+import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class BrandDto {
+
+    @Hidden
+    private Long id;
+
+    @Schema(description = "브랜드 이름", example = "솔티페블")
+    private String title;
+
+    @Schema(description = "브랜드 영문 이름", example = "salty pebble")
+    private String title_eng;
+
+    @Schema(description = "브랜드 설명", example = "솔티페블은 일정한 형식이나 틀을 갖추지 않은 조약돌의 본질을 바라보고 비정형화적인 이미지에 맞춰 시대를 유동하는 컨템포러리 브랜드이다.")
+    private String description;
+
+    @Schema(description = "브랜드 웹 사이트 URL", example = "https://www.saltypebble.com/")
+    private String site_url;
+
+    @Schema(description = "브랜드 이미지 URL", example = "brand_image_url")
+    private String image;
+
+    @Schema(description = "스타일 포인트 ID", example = "1")
+    private Long stylePointId;
+
+    @Builder
+    public BrandDto(Long id, String title, String title_eng, String description, String site_url, String image,
+                    Long stylePointId) {
+        this.id = id;
+        this.title = title;
+        this.title_eng = title_eng;
+        this.description = description;
+        this.site_url = site_url;
+        this.image = image;
+        this.stylePointId = stylePointId;
+    }
+
+    public Brand toEntity(StylePoint stylePoint) {
+        return Brand.builder()
+                .title(this.title)
+                .title_eng(this.title_eng)
+                .description(this.description)
+                .site_url(this.site_url)
+                .image(this.image)
+                .stylePoint(stylePoint)
+                .build();
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/brand/repository/BrandRepository.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/repository/BrandRepository.java
@@ -1,0 +1,10 @@
+package com.thekey.stylekeyserver.brand.repository;
+
+import com.thekey.stylekeyserver.brand.domain.Brand;
+import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BrandRepository extends JpaRepository<Brand, Long> {
+    List<Brand> findBrandByStylePoint(StylePoint stylePoint);
+}

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminService.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminService.java
@@ -1,0 +1,20 @@
+package com.thekey.stylekeyserver.brand.service;
+
+import com.thekey.stylekeyserver.brand.domain.Brand;
+import com.thekey.stylekeyserver.brand.dto.BrandDto;
+import java.util.List;
+
+public interface BrandAdminService {
+
+    Brand create(BrandDto requestDto);
+
+    Brand findById(Long id);
+
+    List<Brand> findAll();
+
+    Brand update(Long id, BrandDto requestDto);
+
+    void delete(Long id);
+
+    BrandDto convertToDto(Brand brand);
+}

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
@@ -1,0 +1,75 @@
+package com.thekey.stylekeyserver.brand.service;
+
+import com.thekey.stylekeyserver.brand.domain.Brand;
+import com.thekey.stylekeyserver.brand.dto.BrandDto;
+import com.thekey.stylekeyserver.brand.repository.BrandRepository;
+import com.thekey.stylekeyserver.exception.ErrorMessage;
+import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
+import com.thekey.stylekeyserver.stylepoint.service.StylePointAdminService;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BrandAdminServiceImpl implements BrandAdminService {
+
+    private final BrandRepository brandRepository;
+    private final StylePointAdminService stylePointAdminService;
+
+    @Override
+    public Brand create(BrandDto requestDto) {
+        StylePoint stylePoint = stylePointAdminService.findById(requestDto.getStylePointId());
+        return brandRepository.save(requestDto.toEntity(stylePoint));
+    }
+
+    @Override
+    public Brand findById(Long id) {
+        return brandRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessage.NOT_FOUND_BRAND.get() + id));
+    }
+
+    @Override
+    public List<Brand> findAll() {
+        return brandRepository.findAll();
+    }
+
+    @Override
+    public Brand update(Long id, BrandDto requestDto) {
+        Brand brand = brandRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessage.NOT_FOUND_BRAND.get() + id));
+
+        StylePoint stylePoint = stylePointAdminService.findById(requestDto.getStylePointId());
+
+        brand.update(requestDto.getTitle(),
+                requestDto.getTitle_eng(),
+                requestDto.getDescription(),
+                requestDto.getSite_url(),
+                requestDto.getImage(),
+                requestDto.toEntity(stylePoint).getStylePoint());
+
+        return brand;
+    }
+
+    @Override
+    public void delete(Long id) {
+        brandRepository.deleteById(id);
+    }
+
+    @Override
+    public BrandDto convertToDto (Brand brand) {
+        return BrandDto.builder()
+                .id(brand.getId())
+                .title(brand.getTitle())
+                .title_eng(brand.getTitle_eng())
+                .description(brand.getDescription())
+                .site_url(brand.getSite_url())
+                .image(brand.getImage())
+                .stylePointId(brand.getStylePoint().getId())
+                .build();
+    }
+
+}

--- a/src/main/java/com/thekey/stylekeyserver/category/controller/CategoryController.java
+++ b/src/main/java/com/thekey/stylekeyserver/category/controller/CategoryController.java
@@ -1,0 +1,39 @@
+package com.thekey.stylekeyserver.category.controller;
+
+import com.thekey.stylekeyserver.category.domain.Category;
+import com.thekey.stylekeyserver.category.service.CategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Category", description = "Category API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/categories")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Read One Category", description = "카테고리 정보 단건 조회")
+    public ResponseEntity<Category> getCategory(@PathVariable Long id) {
+        Optional<Category> optional = Optional.ofNullable(categoryService.findById(id));
+
+        return optional
+                .map(category -> ResponseEntity.ok(category))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping
+    @Operation(summary = "Read All Categories", description = "카테고리 정보 전체 조회")
+    public ResponseEntity<List<Category>> getCategories() {
+        return ResponseEntity.ok(categoryService.findAll());
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/category/domain/Category.java
+++ b/src/main/java/com/thekey/stylekeyserver/category/domain/Category.java
@@ -1,0 +1,30 @@
+package com.thekey.stylekeyserver.category.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_id")
+    private Long id;
+
+    @Column(name = "category_title")
+    private String title;
+
+    @Builder
+    public Category(String title) {
+        this.title = title;
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/category/repository/CategoryRepository.java
+++ b/src/main/java/com/thekey/stylekeyserver/category/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.thekey.stylekeyserver.category.repository;
+
+import com.thekey.stylekeyserver.category.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/thekey/stylekeyserver/category/service/CategoryService.java
+++ b/src/main/java/com/thekey/stylekeyserver/category/service/CategoryService.java
@@ -1,0 +1,10 @@
+package com.thekey.stylekeyserver.category.service;
+
+import com.thekey.stylekeyserver.category.domain.Category;
+import java.util.List;
+
+public interface CategoryService {
+    Category findById(Long id);
+
+    List<Category> findAll();
+}

--- a/src/main/java/com/thekey/stylekeyserver/category/service/CategoryServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/category/service/CategoryServiceImpl.java
@@ -1,0 +1,29 @@
+package com.thekey.stylekeyserver.category.service;
+
+import com.thekey.stylekeyserver.category.domain.Category;
+import com.thekey.stylekeyserver.category.repository.CategoryRepository;
+import com.thekey.stylekeyserver.exception.ErrorMessage;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CategoryServiceImpl implements CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public Category findById(Long id) {
+        return categoryRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessage.NOT_FOUND_CATEGORY.get() + id));
+    }
+
+    @Override
+    public List<Category> findAll() {
+        return categoryRepository.findAll();
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/exception/ErrorMessage.java
+++ b/src/main/java/com/thekey/stylekeyserver/exception/ErrorMessage.java
@@ -1,0 +1,20 @@
+package com.thekey.stylekeyserver.exception;
+
+public enum ErrorMessage {
+
+    NOT_FOUND_STYLE_POINT("StylePoint not found with id: "),
+    NOT_FOUND_BRAND("Brand does not found with id: "),
+    NOT_FOUND_CATEGORY("Category does not found with id: "),
+    NOT_FOUND_COORDINATE_LOOK("Coordinate Look does not found with id: "),
+    NOT_FOUND_ITEM("Item does not found with id: ");
+
+    private String msg;
+
+    ErrorMessage(String msg) {
+        this.msg = msg;
+    }
+
+    public String get() {
+        return msg;
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/stylepoint/controller/StylePointAdminController.java
+++ b/src/main/java/com/thekey/stylekeyserver/stylepoint/controller/StylePointAdminController.java
@@ -1,0 +1,61 @@
+package com.thekey.stylekeyserver.stylepoint.controller;
+
+import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
+import com.thekey.stylekeyserver.stylepoint.dto.StylePointDto;
+import com.thekey.stylekeyserver.stylepoint.service.StylePointAdminService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "StylePoint", description = "StylePoint API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/style-points")
+public class StylePointAdminController {
+
+    private final StylePointAdminService stylePointAdminService;
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Read One StylePoint", description = "스타일포인트 단건 정보 조회")
+    public ResponseEntity<StylePoint> getStylePoint(@PathVariable Long id) {
+        Optional<StylePoint> optional = Optional.ofNullable(stylePointAdminService.findById(id));
+
+        return optional.map(stylePoint -> ResponseEntity.ok(stylePoint))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping
+    @Operation(summary = "Read All StylePoint", description = "스타일포인트 전체 정보 조회.")
+    public ResponseEntity<List<StylePoint>> getStylePoints() {
+        List<StylePoint> stylePoints = stylePointAdminService.findAll();
+
+        return Optional.of(stylePoints)
+                .filter(list -> !list.isEmpty())
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.status(HttpStatus.NO_CONTENT).body(stylePoints));
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Update StylePoint", description = "스타일포인트 정보 수정")
+    public ResponseEntity<StylePoint> update(@PathVariable Long id,
+                                             @RequestBody StylePointDto requestDto) {
+
+        if (id == null) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        Optional<StylePoint> optional = Optional.ofNullable(stylePointAdminService.update(id, requestDto));
+        return optional.map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/stylepoint/domain/StylePoint.java
+++ b/src/main/java/com/thekey/stylekeyserver/stylepoint/domain/StylePoint.java
@@ -1,0 +1,46 @@
+package com.thekey.stylekeyserver.stylepoint.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "StylePoint")
+public class StylePoint {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "style_point_id")
+    private Long id;
+
+    @Column(name = "style_point_title")
+    private String title;
+
+    @Column(name = "style_point_description")
+    private String description;
+
+    @Column(name = "style_point_image")
+    private String image;
+
+    @Builder
+    public StylePoint(String title, String description, String image) {
+        this.title = title;
+        this.description = description;
+        this.image = image;
+    }
+
+    public void update(String title, String description, String image) {
+        this.title = title;
+        this.description = description;
+        this.image = image;
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/stylepoint/dto/StylePointDto.java
+++ b/src/main/java/com/thekey/stylekeyserver/stylepoint/dto/StylePointDto.java
@@ -1,0 +1,40 @@
+package com.thekey.stylekeyserver.stylepoint.dto;
+
+import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class StylePointDto {
+
+    @Hidden
+    private Long id;
+
+    @Schema(description = "스타일포인트 이름", example = "Unique")
+    private String title;
+
+    @Schema(description = "스타일포인트 설명", example = "변화하는 트렌드를 반영하여 평범하지 않고 개성있는 디테일을 추구하는 스타일")
+    private String description;
+
+    @Schema(description = "스타일포인트 이미지", example = "https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/%E1%84%8B%E1%85%B2%E1%84%82%E1%85%B5%E1%84%8F%E1%85%B3%E1%84%91%E1%85%A9%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%90%E1%85%B3.png")
+    private String image;
+
+    @Builder
+    public StylePointDto(String title, String description, String image) {
+        this.title = title;
+        this.description = description;
+        this.image = image;
+    }
+
+    public StylePoint toEntity() {
+        return StylePoint.builder()
+                .title(this.title)
+                .description(this.description)
+                .image(this.image)
+                .build();
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/stylepoint/repository/StylePointRepository.java
+++ b/src/main/java/com/thekey/stylekeyserver/stylepoint/repository/StylePointRepository.java
@@ -1,0 +1,9 @@
+package com.thekey.stylekeyserver.stylepoint.repository;
+
+import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StylePointRepository extends JpaRepository<StylePoint, Long> {
+}

--- a/src/main/java/com/thekey/stylekeyserver/stylepoint/service/StylePointAdminService.java
+++ b/src/main/java/com/thekey/stylekeyserver/stylepoint/service/StylePointAdminService.java
@@ -1,0 +1,15 @@
+package com.thekey.stylekeyserver.stylepoint.service;
+
+import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
+import com.thekey.stylekeyserver.stylepoint.dto.StylePointDto;
+import java.util.List;
+
+public interface StylePointAdminService {
+
+    StylePoint findById(Long id);
+
+    List<StylePoint> findAll();
+
+    StylePoint update(Long id, StylePointDto requestDto);
+
+}

--- a/src/main/java/com/thekey/stylekeyserver/stylepoint/service/StylePointAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/stylepoint/service/StylePointAdminServiceImpl.java
@@ -1,0 +1,43 @@
+package com.thekey.stylekeyserver.stylepoint.service;
+
+import com.thekey.stylekeyserver.exception.ErrorMessage;
+import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
+import com.thekey.stylekeyserver.stylepoint.dto.StylePointDto;
+import com.thekey.stylekeyserver.stylepoint.repository.StylePointRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StylePointAdminServiceImpl implements StylePointAdminService {
+
+    private final StylePointRepository stylePointRepository;
+
+    @Override
+    public StylePoint findById(Long id) {
+        return stylePointRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessage.NOT_FOUND_STYLE_POINT.get() + id));
+    }
+
+    @Override
+    public List<StylePoint> findAll() {
+        return stylePointRepository.findAll();
+    }
+
+    @Override
+    public StylePoint update(Long id, StylePointDto requestDto) {
+        StylePoint stylePoint = stylePointRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessage.NOT_FOUND_STYLE_POINT.get() + id));
+
+        stylePoint.update(requestDto.getTitle(),
+                requestDto.getDescription(),
+                requestDto.getImage());
+
+        return stylePoint;
+    }
+
+}

--- a/src/main/java/com/thekey/stylekeyserver/swagger/SwaggerConfig.java
+++ b/src/main/java/com/thekey/stylekeyserver/swagger/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package com.thekey.stylekeyserver.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("StyleKEY API")
+                .description("패션 취향 테스트를 통한 사용자 맞춤형 패션 정보 제공 서비스")
+                .version("1.0.0");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,20 +15,23 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
-    show-sql: true
+      ddl-auto: create-drop
     properties:
       hibernate:
         format_sql: true
+    defer-datasource-initialization: true
 
+  sql:
+    init:
+      mode: always
 
 logging:
   level:
     org.hibernate.SQL: DEBUG
+    org.hibernate.type: TRACE
     org.springframework.transaction: DEBUG
 
 springdoc:
-  packages-to-scan: com.colabear754.springdoc_example.controllers
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
   swagger-ui:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,47 @@
+-- StylePoint
+insert into style_point (style_point_title, style_point_description, style_point_image)
+values ('Unique', '변화하는 트렌드를 반영하여 평범하지 않고 개성있는 디테일을 추구하는 스타일',
+'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/%E1%84%8B%E1%85%B2%E1%84%82%E1%85%B5%E1%84%8F%E1%85%B3%E1%84%91%E1%85%A9%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%90%E1%85%B3.png');
+
+insert into style_point (style_point_title, style_point_description, style_point_image)
+values ('Street', '격식을 갖추지 않고 길거리에서 편하게 입을 수 있는 힙한 스타일',
+'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/%E1%84%89%E1%85%B3%E1%84%90%E1%85%B3%E1%84%85%E1%85%B5%E1%86%BA%E1%84%91%E1%85%A9%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%90%E1%85%B3.png');
+
+insert into style_point (style_point_title, style_point_description, style_point_image)
+values ('Modern', '장식적인 것 없이 깔끔하고 심플하며 직선적인 실루엣을 추구하는 스타일',
+'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/%E1%84%86%E1%85%A9%E1%84%83%E1%85%A5%E1%86%AB%E1%84%91%E1%85%A9%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%90%E1%85%B3.png');
+
+insert into style_point (style_point_title, style_point_description, style_point_image)
+values ('Normal', '일상적이고 평범한 착장이 무난하지 않도록 센스있는 포인트가 들어간 스타일',
+'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/%E1%84%82%E1%85%A9%E1%84%86%E1%85%A5%E1%86%AF%E1%84%91%E1%85%A9%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%90%E1%85%B3.png');
+
+insert into style_point (style_point_title, style_point_description, style_point_image)
+values ('Lovely', '사랑스러운 소녀같이 귀엽고 로맨틱하면서 여성스러운 무드를 강조한 스타일',
+'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/%E1%84%85%E1%85%A5%E1%84%87%E1%85%B3%E1%86%AF%E1%84%85%E1%85%B5%E1%84%91%E1%85%A9%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%90%E1%85%B3.jpg');
+
+insert into style_point (style_point_title, style_point_description, style_point_image)
+values ('Retro', '1990-2000년대의 감성을 재해석하여 오래된 듯한 멋진 느낌이 드는 스타일',
+'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/%E1%84%85%E1%85%A6%E1%84%90%E1%85%B3%E1%84%85%E1%85%A9%E1%84%91%E1%85%A9%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%90%E1%85%B3.jpg');
+
+insert into style_point (style_point_title, style_point_description, style_point_image)
+values ('Glam', '섹시함이 강조되는 화려하고 여성스러운 스타일',
+'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/%E1%84%80%E1%85%B3%E1%86%AF%E1%84%85%E1%85%A2%E1%86%B7%E1%84%91%E1%85%A9%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%90%E1%85%B3.png');
+
+insert into style_point (style_point_title, style_point_description, style_point_image)
+values ('Active', '스포츠웨어와 일상복의 경계를 허물고 활동적인 이미지를 표현하는 스타일',
+'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/%E1%84%8B%E1%85%A6%E1%86%A8%E1%84%90%E1%85%B5%E1%84%87%E1%85%B3%E1%84%91%E1%85%A9%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%90%E1%85%B3.png');
+
+-- Category
+insert into category (category_title) values ('TOP');
+
+insert into category (category_title) values ('OUTER');
+
+insert into category (category_title) values ('DRESS');
+
+insert into category (category_title) values ('BOTTOM');
+
+insert into category (category_title) values ('BAG');
+
+insert into category (category_title) values ('SHOES');
+
+insert into category (category_title) values ('ACC');


### PR DESCRIPTION
이전 버전과 동일한 기능이지만 전체적인 리팩토링을 거친 결과입니다.
리팩토링을 통해 수정된 부분은 크게 2가지 입니다.
**1. Optional을 활용하여 null 객체 처리 및 코드 안정성을 강화
2. Swagger를 적용하여 API를 문서화 작업 진행**

### 관리자페이지 기능
**1. 브랜드 기능**
- 브랜드 정보 등록
- 브랜드 정보 전체 조회
- 브랜드 정보 단건 조회
- 브랜드 정보 수정
- 브랜드 정보 삭제

**2. 스타일포인트 기능**
- 스타일포인트 정보 전체 조회
- 스타일포인트 정보 단건 조회
- 스타일포인트 정보 수정


### 서비스페이지 기능
**1. 카테고리 기능**
- 카테고리 정보 전체 조회
- 카테고리 정보 단건 조회

---
### 기능 외 추가 작업
스타일포인트, 카테고리 초기 데이터 추가 (data.sql)
SwaggerConfig, ErrorMessge, BaseTimeEntity 추가