### PR TITLE
Fix: 토큰 없어도 swagger 확인 가능하도록 security config 수정 완료

### DIFF
--- a/src/main/java/com/thekey/stylekeyserver/global/security/SecurityConfig.java
+++ b/src/main/java/com/thekey/stylekeyserver/global/security/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -66,8 +67,8 @@ public class SecurityConfig {
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
         http.authorizeRequests()
-                .requestMatchers("/v3/api-docs/**").permitAll()
                 .requestMatchers("/swagger-ui/**").permitAll()
+                .requestMatchers("/v3/api-docs/**").permitAll()
                 .requestMatchers("/api/auth/**").permitAll()
                 .anyRequest().authenticated()
 


### PR DESCRIPTION
기존 security config를 /api/auth에 대해서만 permitAll() 적용을 했는데
이제 토큰 없이도 스웨거 확인 가능합니다.
/swagger-ui/index.html로 접속해야 합니다.