### PR TITLE
Fix: UserDetailsImpl.java 파일 @override gerUserName에서 엔티티의 getter 이용해서 수정

### DIFF
--- a/src/main/java/com/thekey/stylekeyserver/global/security/UserDetailsImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/global/security/UserDetailsImpl.java
@@ -35,7 +35,7 @@ public class UserDetailsImpl implements UserDetails {
 
     @Override
     public String getUsername() {
-        return authEntity.toString();
+        return authEntity.getUserId();
     }
 
     @Override


### PR DESCRIPTION
기존 코드가 아래와 같이 되어있었으나
`@Override
    public String getUsername() {
        return authEntity.toString();
    }`
엔티티 객체에서 toString을 가져오면 메모리 참조 주소를 가지고 오는 문제점이 있어
auth entity @Getter를 통해 정의된 getUserId()로 대체하였습니다.