### PR TITLE
단건 테스트 결과 삭제 기능 구현

### DIFF
--- a/src/main/java/com/thekey/stylekeyserver/test/controller/TestController.java
+++ b/src/main/java/com/thekey/stylekeyserver/test/controller/TestController.java
@@ -10,7 +10,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,5 +40,12 @@ public class TestController {
     public ResponseEntity<List<TestResultResponse>> getTestResults() {
         String userId = SecurityContextHolder.getContext().getAuthentication().getName();
         return ResponseEntity.ok(testResultService.getTestResult(userId));
+    }
+
+    @DeleteMapping("/test-result/{testResultId}")
+    public ResponseEntity<Void> deleteTestResult(@PathVariable Long testResultId) {
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+        testResultService.deleteTestResult(testResultId, userId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/test/controller/TestController.java
+++ b/src/main/java/com/thekey/stylekeyserver/test/controller/TestController.java
@@ -46,6 +46,6 @@ public class TestController {
     public ResponseEntity<Void> deleteTestResult(@PathVariable Long testResultId) {
         String userId = SecurityContextHolder.getContext().getAuthentication().getName();
         testResultService.deleteTestResult(testResultId, userId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/test/repository/TestResultRepository.java
+++ b/src/main/java/com/thekey/stylekeyserver/test/repository/TestResultRepository.java
@@ -10,4 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface TestResultRepository extends JpaRepository<TestResult, Long> {
 
     List<TestResult> findAllByUser(AuthEntity user);
+
+    void deleteByUserAndId(AuthEntity user, Long id);
 }

--- a/src/main/java/com/thekey/stylekeyserver/test/service/TestResultService.java
+++ b/src/main/java/com/thekey/stylekeyserver/test/service/TestResultService.java
@@ -47,4 +47,10 @@ public class TestResultService {
             .map(TestResultResponse::of)
             .toList();
     }
+
+    @Transactional
+    public void deleteTestResult(Long testResultId, String userId) {
+        AuthEntity user = authRepository.findByUserId(userId).orElseThrow();
+        testResultRepository.deleteByUserAndId(user, testResultId);
+    }
 }


### PR DESCRIPTION
delete api 구현했습니다.

delete는 반환타입이 없어서 알아본 결과 noContent로 204응답을 반환하는 방법도 많이 사용하고 해서 사용해 봤는데

저희는 응답코드를 전부 200(ok)로 통일하는게 좋을까요?

또한 레포지토리 부분에서 User정보도 받아와서 해당 유저정보와 테스트 결과의 id값이 일치하는 결과를 삭제하도록 했는데

테스트결과의 id값만 있어도 삭제가 가능한 걸로 알고 있습니다. 이 부분에 대해서는 어떤 테스트 결과 id만 가지고 삭제를 진행할지 지금 구현한 것처럼 유저를 확인하고 나서 삭제처리를 할지에 대한 의견 부탁드립니다.