### PR TITLE
Feature: 스타일포인트 서비스페이지 조회 API 기능 추가

### DIFF
--- a/src/main/java/com/thekey/stylekeyserver/stylepoint/controller/StylePointAdminController.java
+++ b/src/main/java/com/thekey/stylekeyserver/stylepoint/controller/StylePointAdminController.java
@@ -1,14 +1,15 @@
 package com.thekey.stylekeyserver.stylepoint.controller;
 
 import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
-import com.thekey.stylekeyserver.stylepoint.dto.StylePointDto;
+import com.thekey.stylekeyserver.stylepoint.dto.request.StylePointRequest;
+import com.thekey.stylekeyserver.stylepoint.dto.response.StylePointResponse;
 import com.thekey.stylekeyserver.stylepoint.service.StylePointAdminService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,35 +28,39 @@ public class StylePointAdminController {
 
     @GetMapping("/{id}")
     @Operation(summary = "Read One StylePoint", description = "스타일포인트 단건 정보 조회")
-    public ResponseEntity<StylePoint> getStylePoint(@PathVariable Long id) {
+    public ResponseEntity<StylePointResponse> getStylePoint(@PathVariable Long id) {
         Optional<StylePoint> optional = Optional.ofNullable(stylePointAdminService.findById(id));
 
-        return optional.map(stylePoint -> ResponseEntity.ok(stylePoint))
+        return optional.map(stylePoint -> ResponseEntity.ok(StylePointResponse.of(stylePoint)))
                 .orElse(ResponseEntity.notFound().build());
+
     }
 
     @GetMapping
     @Operation(summary = "Read All StylePoint", description = "스타일포인트 전체 정보 조회.")
-    public ResponseEntity<List<StylePoint>> getStylePoints() {
+    public ResponseEntity<List<StylePointResponse>> getStylePoints() {
         List<StylePoint> stylePoints = stylePointAdminService.findAll();
 
-        return Optional.of(stylePoints)
-                .filter(list -> !list.isEmpty())
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.status(HttpStatus.NO_CONTENT).body(stylePoints));
+        if (stylePoints.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.ok(stylePoints.stream()
+                .map(StylePointResponse::of)
+                .collect(Collectors.toList()));
+
     }
 
     @PutMapping("/{id}")
     @Operation(summary = "Update StylePoint", description = "스타일포인트 정보 수정")
-    public ResponseEntity<StylePoint> update(@PathVariable Long id,
-                                             @RequestBody StylePointDto requestDto) {
+    public ResponseEntity<StylePointResponse> update(@PathVariable Long id,
+                                                     @RequestBody StylePointRequest requestDto) {
 
         if (id == null) {
             return ResponseEntity.badRequest().build();
         }
 
-        Optional<StylePoint> optional = Optional.ofNullable(stylePointAdminService.update(id, requestDto));
-        return optional.map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+        StylePoint updated = stylePointAdminService.update(id, requestDto);
+        return ResponseEntity.ok(StylePointResponse.of(updated));
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/stylepoint/controller/StylePointApiController.java
+++ b/src/main/java/com/thekey/stylekeyserver/stylepoint/controller/StylePointApiController.java
@@ -1,0 +1,48 @@
+package com.thekey.stylekeyserver.stylepoint.controller;
+
+import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
+import com.thekey.stylekeyserver.stylepoint.dto.response.StylePointResponse;
+import com.thekey.stylekeyserver.stylepoint.service.StylePointAdminService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "StylePoint", description = "StylePoint API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/style-points")
+public class StylePointApiController {
+
+    private final StylePointAdminService stylePointAdminService;
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Read One StylePoint", description = "스타일포인트 단건 정보 조회")
+    public ResponseEntity<StylePointResponse> getStylePoint(@PathVariable Long id) {
+        Optional<StylePoint> optional = Optional.ofNullable(stylePointAdminService.findById(id));
+
+        return optional.map(stylePoint -> ResponseEntity.ok(StylePointResponse.of(stylePoint)))
+                .orElse(ResponseEntity.notFound().build());
+
+    }
+
+    @GetMapping
+    public ResponseEntity<List<StylePointResponse>> getStylePoints() {
+        List<StylePoint> stylePoints = stylePointAdminService.findAll();
+
+        if (stylePoints.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.ok(stylePoints.stream()
+                .map(StylePointResponse::of)
+                .collect(Collectors.toList()));
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/stylepoint/controller/StylePointApiController.java
+++ b/src/main/java/com/thekey/stylekeyserver/stylepoint/controller/StylePointApiController.java
@@ -34,6 +34,7 @@ public class StylePointApiController {
     }
 
     @GetMapping
+    @Operation(summary = "Read All StylePoint", description = "스타일포인트 전체 정보 조회")
     public ResponseEntity<List<StylePointResponse>> getStylePoints() {
         List<StylePoint> stylePoints = stylePointAdminService.findAll();
 

--- a/src/main/java/com/thekey/stylekeyserver/stylepoint/dto/request/StylePointRequest.java
+++ b/src/main/java/com/thekey/stylekeyserver/stylepoint/dto/request/StylePointRequest.java
@@ -1,9 +1,8 @@
-package com.thekey.stylekeyserver.stylepoint.dto;
+package com.thekey.stylekeyserver.stylepoint.dto.request;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
@@ -12,10 +11,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @JsonNaming(SnakeCaseStrategy.class)
-public class StylePointDto {
-
-    @Hidden
-    private Long id;
+public class StylePointRequest {
 
     @Schema(description = "스타일포인트 이름", example = "Unique")
     private String title;
@@ -27,17 +23,17 @@ public class StylePointDto {
     private String image;
 
     @Builder
-    public StylePointDto(String title, String description, String image) {
+    public StylePointRequest(String title, String description, String image) {
         this.title = title;
         this.description = description;
         this.image = image;
     }
 
-    public StylePoint toEntity() {
-        return StylePoint.builder()
-                .title(this.title)
-                .description(this.description)
-                .image(this.image)
+    public static StylePointRequest of(StylePoint stylePoint) {
+        return StylePointRequest.builder()
+                .title(stylePoint.getTitle())
+                .description(stylePoint.getDescription())
+                .image(stylePoint.getImage())
                 .build();
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/stylepoint/dto/response/StylePointResponse.java
+++ b/src/main/java/com/thekey/stylekeyserver/stylepoint/dto/response/StylePointResponse.java
@@ -1,0 +1,44 @@
+package com.thekey.stylekeyserver.stylepoint.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@JsonNaming(SnakeCaseStrategy.class)
+public class StylePointResponse {
+
+    @Schema(description = "스타일포인트 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "스타일포인트 이름", example = "Unique")
+    private String title;
+
+    @Schema(description = "스타일포인트 설명", example = "변화하는 트렌드를 반영하여 평범하지 않고 개성있는 디테일을 추구하는 스타일")
+    private String description;
+
+    @Schema(description = "스타일포인트 이미지", example = "https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/%E1%84%8B%E1%85%B2%E1%84%82%E1%85%B5%E1%84%8F%E1%85%B3%E1%84%91%E1%85%A9%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%90%E1%85%B3.png")
+    private String image;
+
+    @Builder
+    public StylePointResponse(Long id, String title, String description, String image) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.image = image;
+    }
+
+    public static StylePointResponse of(StylePoint stylePoint) {
+        return StylePointResponse.builder()
+                .id(stylePoint.getId())
+                .title(stylePoint.getTitle())
+                .description(stylePoint.getDescription())
+                .image(stylePoint.getImage())
+                .build();
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/stylepoint/service/StylePointAdminService.java
+++ b/src/main/java/com/thekey/stylekeyserver/stylepoint/service/StylePointAdminService.java
@@ -1,7 +1,7 @@
 package com.thekey.stylekeyserver.stylepoint.service;
 
 import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
-import com.thekey.stylekeyserver.stylepoint.dto.StylePointDto;
+import com.thekey.stylekeyserver.stylepoint.dto.request.StylePointRequest;
 import java.util.List;
 
 public interface StylePointAdminService {
@@ -10,6 +10,6 @@ public interface StylePointAdminService {
 
     List<StylePoint> findAll();
 
-    StylePoint update(Long id, StylePointDto requestDto);
+    StylePoint update(Long id, StylePointRequest requestDto);
 
 }

--- a/src/main/java/com/thekey/stylekeyserver/stylepoint/service/StylePointAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/stylepoint/service/StylePointAdminServiceImpl.java
@@ -2,7 +2,7 @@ package com.thekey.stylekeyserver.stylepoint.service;
 
 import com.thekey.stylekeyserver.stylepoint.StylePointErrorMessage;
 import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
-import com.thekey.stylekeyserver.stylepoint.dto.StylePointDto;
+import com.thekey.stylekeyserver.stylepoint.dto.request.StylePointRequest;
 import com.thekey.stylekeyserver.stylepoint.repository.StylePointRepository;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
@@ -29,7 +29,7 @@ public class StylePointAdminServiceImpl implements StylePointAdminService {
     }
 
     @Override
-    public StylePoint update(Long id, StylePointDto requestDto) {
+    public StylePoint update(Long id, StylePointRequest requestDto) {
         StylePoint stylePoint = stylePointRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(StylePointErrorMessage.NOT_FOUND_STYLE_POINT.get() + id));
 


### PR DESCRIPTION
### 스타일포인트 서비스페이지 조회 API 기능 추가했습니다. 
조회는 Admin Service와 동일한 로직이어서 그냥 재사용했습니다. 이후 서비스페이지의 다른 기능이 추가될 경우 Api Service를 따로 만들어서 작업할 예정입니다!
기존의 dto를 하나로 통일했었는데, 이번에 request와 response로 분리해서 다시 구성해서 어드민 버전도 전체적으로 코드 수정이 있었습니다!

