### PR TITLE
Fix: Auth Swagger 등록 및 AuthEntity equals, hashCode 재정의, dto 스네이크 케이스로 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	// implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -35,8 +34,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-	implementation 'org.springframework.session:spring-session-jdbc'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	testImplementation 'io.projectreactor:reactor-test'

--- a/src/main/java/com/thekey/stylekeyserver/auth/controller/AuthController.java
+++ b/src/main/java/com/thekey/stylekeyserver/auth/controller/AuthController.java
@@ -15,12 +15,15 @@ import com.thekey.stylekeyserver.auth.dto.request.AuthRequestDto;
 import com.thekey.stylekeyserver.auth.service.AuthService;
 import com.thekey.stylekeyserver.global.response.ApiResponseDto;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "Auth", description = "Auth API")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -28,11 +31,13 @@ public class AuthController {
     private final AuthService authService;
 
    @PostMapping("/sign-up")
+   @Operation(summary = "sign-up", description = "회원 가입")
     public ResponseEntity <ApiResponseDto> signUp (@RequestBody @Valid AuthRequestDto authRequestDto){
         return authService.signUp(authRequestDto);
     }
 
     @PostMapping("/login")
+    @Operation(summary = "login", description = "로그인")
     public ResponseEntity <ApiResponseDto> login (@RequestBody @Valid AuthRequestDto authRequestDto,
                                                      HttpServletResponse response){
         return authService.login(authRequestDto,response);

--- a/src/main/java/com/thekey/stylekeyserver/auth/dto/request/AuthRequestDto.java
+++ b/src/main/java/com/thekey/stylekeyserver/auth/dto/request/AuthRequestDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 public class AuthRequestDto {
      @NotBlank(message = "ID를 입력해주세요.")
-    private String memberId;
+    private String member_id;
 
     @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;

--- a/src/main/java/com/thekey/stylekeyserver/auth/dto/response/AuthResponseDto.java
+++ b/src/main/java/com/thekey/stylekeyserver/auth/dto/response/AuthResponseDto.java
@@ -6,11 +6,11 @@ import lombok.Getter;
 @Getter
 @Builder
 public class AuthResponseDto {
-    private String memberId;
+    private String member_id;
 
-    public static AuthResponseDto of(String memberId) {
+    public static AuthResponseDto of(String member_id) {
         return AuthResponseDto.builder()
-                .memberId(memberId)
+                .member_id(member_id)
                 .build();
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/auth/entity/AuthEntity.java
+++ b/src/main/java/com/thekey/stylekeyserver/auth/entity/AuthEntity.java
@@ -1,6 +1,7 @@
 package com.thekey.stylekeyserver.auth.entity;
 
 import java.time.OffsetDateTime;
+import java.util.Objects;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -38,5 +39,18 @@ public class AuthEntity {
   
     public void changePassword(String newPassword) {
         this.password = newPassword;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AuthEntity that = (AuthEntity) o;
+        return Objects.equals(userId, that.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId);
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/auth/service/AuthService.java
+++ b/src/main/java/com/thekey/stylekeyserver/auth/service/AuthService.java
@@ -32,7 +32,7 @@ public class AuthService {
     @Transactional
     public ResponseEntity<ApiResponseDto> signUp(AuthRequestDto authRequestDto) {
 
-        Optional<AuthEntity> member = authRepository.findByUserId(authRequestDto.getMemberId());
+        Optional<AuthEntity> member = authRepository.findByUserId(authRequestDto.getMember_id());
 
         if (member.isPresent()) {
             return ResponseEntity.ok(ApiResponseDto.of(ErrorType.USER_EXIST));
@@ -40,13 +40,13 @@ public class AuthService {
 
         String encodedPassword = passwordEncoder.encode(authRequestDto.getPassword());
         OffsetDateTime now = OffsetDateTime.now();
-        authRepository.save(AuthEntity.of(authRequestDto.getMemberId(), encodedPassword, now));
+        authRepository.save(AuthEntity.of(authRequestDto.getMember_id(), encodedPassword, now));
         return ResponseEntity.ok(ApiResponseDto.of(SuccessType.SIGN_UP_SUCCESS));
     }
 
     public ResponseEntity<ApiResponseDto> login(AuthRequestDto authRequestDto, HttpServletResponse response) {
 
-        Optional<AuthEntity> member = authRepository.findByUserId(authRequestDto.getMemberId());
+        Optional<AuthEntity> member = authRepository.findByUserId(authRequestDto.getMember_id());
 
         if (member.isEmpty()) {
             return ResponseEntity.ok(ApiResponseDto.of(ErrorType.USER_NOT_FOUND));
@@ -56,7 +56,7 @@ public class AuthService {
             return ResponseEntity.ok(ApiResponseDto.of(ErrorType.PASSWORD_MISMATCH));
         }
 
-        TokenDto tokenDto = new TokenDto(jwtUtil.createToken(authRequestDto.getMemberId()));
+        TokenDto tokenDto = new TokenDto(jwtUtil.createToken(authRequestDto.getMember_id()));
         response.addHeader(JwtUtil.AUTHORIZATION_HEADER, tokenDto.getAccessToken());
 
         return ResponseEntity.ok(ApiResponseDto.of(SuccessType.LOG_IN_SUCCESS,
@@ -66,7 +66,7 @@ public class AuthService {
     @Transactional
     public ResponseEntity<ApiResponseDto> changePassword(AuthRequestDto authRequestDto) {
 
-        Optional<AuthEntity> member = authRepository.findByUserId(authRequestDto.getMemberId());
+        Optional<AuthEntity> member = authRepository.findByUserId(authRequestDto.getMember_id());
 
         if (member.isEmpty()) {
             return ResponseEntity


### PR DESCRIPTION
1. Auth 관련 서비스 페이지 스웨거에 등록했습니다.

2. AuthEntity 
equals, hashCode를 재정의하여 AuthEntity 인스턴스가 같은 userId 값을 갖는 경우에 동일하게 취급받을 수 있도록 수정하였습니다. (@DataJpaTest, @SpringBootTest)

3. Dto - 스네이크 케이스
스네이크 케이스로 request, response Dto 형식을 통일하였습니다.