### PR TITLE
Refactor: 로그인 시 엑세스, 리프레시 토큰 response body 반환으로 수정 && Feat: 토큰 재발급 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 	compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+
+	implementation 'org.slf4j:slf4j-api:1.7.32'
+	implementation 'ch.qos.logback:logback-classic:1.2.6'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/thekey/stylekeyserver/auth/controller/AuthController.java
+++ b/src/main/java/com/thekey/stylekeyserver/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.thekey.stylekeyserver.auth.dto.request.AuthReissueRequestDto;
 import com.thekey.stylekeyserver.auth.dto.request.AuthRequestDto;
 import com.thekey.stylekeyserver.auth.service.AuthService;
 import com.thekey.stylekeyserver.global.response.ApiResponseDto;
@@ -31,17 +32,22 @@ public class AuthController {
     private final AuthService authService;
 
    @PostMapping("/sign-up")
-   @Operation(summary = "sign-up", description = "회원 가입")
+   @Operation(summary = "sign-up", description = "회원 가입 API입니다.")
     public ResponseEntity <ApiResponseDto> signUp (@RequestBody @Valid AuthRequestDto authRequestDto){
         return authService.signUp(authRequestDto);
     }
 
     @PostMapping("/login")
-    @Operation(summary = "login", description = "로그인")
+    @Operation(summary = "login", description = "로그인 API로 access_token과 refresh_token이 발급됩니다.")
     public ResponseEntity <ApiResponseDto> login (@RequestBody @Valid AuthRequestDto authRequestDto,
                                                      HttpServletResponse response){
         return authService.login(authRequestDto,response);
     }
 
+    @PostMapping("/re-issue")
+    @Operation(summary = "re-issue", description = "토큰 재발급 시 access_token, refresh_token에서 Bearer와 공백은 제거하고 요청해주세요.")
+    public ResponseEntity <ApiResponseDto> reissueToken(@RequestBody @Valid AuthReissueRequestDto authReissueRequestDto, HttpServletResponse response) {
+        return authService.reissueToken(authReissueRequestDto, response);
+    }
    
 }

--- a/src/main/java/com/thekey/stylekeyserver/auth/dto/request/AuthReissueRequestDto.java
+++ b/src/main/java/com/thekey/stylekeyserver/auth/dto/request/AuthReissueRequestDto.java
@@ -1,0 +1,18 @@
+package com.thekey.stylekeyserver.auth.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthReissueRequestDto {
+    @NotEmpty
+    private String access_token;
+
+    @NotEmpty
+    private String refresh_token;
+
+}

--- a/src/main/java/com/thekey/stylekeyserver/auth/dto/response/AuthReissueResponseDto.java
+++ b/src/main/java/com/thekey/stylekeyserver/auth/dto/response/AuthReissueResponseDto.java
@@ -1,0 +1,18 @@
+package com.thekey.stylekeyserver.auth.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class AuthReissueResponseDto {
+    private final String access_token;
+    
+    public static AuthReissueResponseDto of(String access_token) {
+        return AuthReissueResponseDto.builder()
+                .access_token(access_token)
+                .build();
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/auth/dto/response/AuthResponseDto.java
+++ b/src/main/java/com/thekey/stylekeyserver/auth/dto/response/AuthResponseDto.java
@@ -7,10 +7,14 @@ import lombok.Getter;
 @Builder
 public class AuthResponseDto {
     private String member_id;
+    private final String access_token;
+    private final String refresh_token;
 
-    public static AuthResponseDto of(String member_id) {
+    public static AuthResponseDto of(String member_id, String access_token, String refresh_token) {
         return AuthResponseDto.builder()
                 .member_id(member_id)
+                .access_token(access_token)
+                .refresh_token(refresh_token)
                 .build();
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/global/jwt/TokenDto.java
+++ b/src/main/java/com/thekey/stylekeyserver/global/jwt/TokenDto.java
@@ -1,17 +1,21 @@
 package com.thekey.stylekeyserver.global.jwt;
 
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@JsonNaming(SnakeCaseStrategy.class)
 public class TokenDto {
 
     private String accessToken;
+    private final String refreshToken;
 
-    public TokenDto(String accessToken) {
+    public TokenDto(String accessToken, String refreshToken) {
         this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
     }
 
 }

--- a/src/main/java/com/thekey/stylekeyserver/global/response/SuccessType.java
+++ b/src/main/java/com/thekey/stylekeyserver/global/response/SuccessType.java
@@ -10,7 +10,8 @@ public enum SuccessType {
     SIGN_UP_SUCCESS(200, "회원 가입에 성공했습니다."),
     LOG_IN_SUCCESS(200, "로그인되었습니다."),
     CHANGE_PASSWORD(200, "비밀번호가 변경되었습니다."),
-    USER_EXIST(200, "존재하는 회원입니다.");
+    USER_EXIST(200, "존재하는 회원입니다."),
+    REISSUE_SUCCESS(200, "토큰 재발급이 성공적으로 되었습니다.");
 
 
     private final int statusCode;


### PR DESCRIPTION
postman으로 테스트 해봤을 때 로그인 성공 시 유저 아이디, 엑세스 토큰, 리프레시 토큰 발급 정상적으로 되며
토큰 재발급 요청 시 'Bearer ' request body에 제거하고 요청했을 때 정상적으로 엑세스 토큰 반환합니다.
토큰 DB 저장 로직 추가로 필요합니다.