### PR TITLE
Feat: RTR(Refresh Token Rotation) 도입, refresh token db 저장, 토큰 재발급 시 유저 검증 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,8 @@ dependencies {
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 
-	implementation 'org.slf4j:slf4j-api:1.7.32'
-	implementation 'ch.qos.logback:logback-classic:1.2.6'
+	// implementation 'org.slf4j:slf4j-api:1.7.32'
+	// implementation 'ch.qos.logback:logback-classic:1.2.6'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/thekey/stylekeyserver/auth/dto/request/AuthReissueRequestDto.java
+++ b/src/main/java/com/thekey/stylekeyserver/auth/dto/request/AuthReissueRequestDto.java
@@ -10,6 +10,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AuthReissueRequestDto {
     @NotEmpty
+    private String user_id;
+
+    @NotEmpty
     private String access_token;
 
     @NotEmpty

--- a/src/main/java/com/thekey/stylekeyserver/auth/dto/request/AuthRequestDto.java
+++ b/src/main/java/com/thekey/stylekeyserver/auth/dto/request/AuthRequestDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 public class AuthRequestDto {
      @NotBlank(message = "ID를 입력해주세요.")
-    private String member_id;
+    private String user_id;
 
     @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;

--- a/src/main/java/com/thekey/stylekeyserver/auth/dto/response/AuthReissueResponseDto.java
+++ b/src/main/java/com/thekey/stylekeyserver/auth/dto/response/AuthReissueResponseDto.java
@@ -2,17 +2,36 @@ package com.thekey.stylekeyserver.auth.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 @Builder
-@RequiredArgsConstructor
 public class AuthReissueResponseDto {
     private final String access_token;
+    private final String refresh_token;
     
-    public static AuthReissueResponseDto of(String access_token) {
-        return AuthReissueResponseDto.builder()
-                .access_token(access_token)
-                .build();
+    public static AuthReissueResponseDtoBuilder builder() {
+        return new AuthReissueResponseDtoBuilder();
+    }
+
+    public static class AuthReissueResponseDtoBuilder {
+        private String access_token;
+        private String refresh_token;
+
+        AuthReissueResponseDtoBuilder() {
+        }
+
+        public AuthReissueResponseDtoBuilder access_token(String access_token) {
+            this.access_token = access_token;
+            return this;
+        }
+
+        public AuthReissueResponseDtoBuilder refresh_token(String refresh_token) {
+            this.refresh_token = refresh_token;
+            return this;
+        }
+
+        public AuthReissueResponseDto build() {
+            return new AuthReissueResponseDto(this.access_token, this.refresh_token);
+        }
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/auth/dto/response/AuthResponseDto.java
+++ b/src/main/java/com/thekey/stylekeyserver/auth/dto/response/AuthResponseDto.java
@@ -6,13 +6,13 @@ import lombok.Getter;
 @Getter
 @Builder
 public class AuthResponseDto {
-    private String member_id;
+    private String user_id;
     private final String access_token;
     private final String refresh_token;
 
-    public static AuthResponseDto of(String member_id, String access_token, String refresh_token) {
+    public static AuthResponseDto of(String user_id, String access_token, String refresh_token) {
         return AuthResponseDto.builder()
-                .member_id(member_id)
+                .user_id(user_id)
                 .access_token(access_token)
                 .refresh_token(refresh_token)
                 .build();

--- a/src/main/java/com/thekey/stylekeyserver/auth/entity/AuthEntity.java
+++ b/src/main/java/com/thekey/stylekeyserver/auth/entity/AuthEntity.java
@@ -29,6 +29,9 @@ public class AuthEntity {
     @Column(nullable = false)
     private String password;
 
+    @Column(name = "refresh_token")
+    private String refreshToken;
+
     public static AuthEntity of(String userId, String password, OffsetDateTime createdAt){
         return AuthEntity.builder()
                 .userId(userId)
@@ -39,6 +42,14 @@ public class AuthEntity {
   
     public void changePassword(String newPassword) {
         this.password = newPassword;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
     }
 
     @Override

--- a/src/main/java/com/thekey/stylekeyserver/auth/service/AuthService.java
+++ b/src/main/java/com/thekey/stylekeyserver/auth/service/AuthService.java
@@ -67,6 +67,9 @@ public class AuthService {
         String accessToken = jwtUtil.createToken(authRequestDto.getUser_id());
         String refreshToken = jwtUtil.createRefreshToken(authRequestDto.getUser_id());
 
+        member.get().setRefreshToken(refreshToken);
+        authRepository.save(member.get());
+
         TokenDto tokenDto = new TokenDto(accessToken, refreshToken);
         response.addHeader(JwtUtil.AUTHORIZATION_HEADER, tokenDto.getAccessToken());
 

--- a/src/main/java/com/thekey/stylekeyserver/auth/service/AuthService.java
+++ b/src/main/java/com/thekey/stylekeyserver/auth/service/AuthService.java
@@ -31,7 +31,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class AuthService {
-    private final Logger log = LoggerFactory.getLogger(AuthService.class);
+    // private final Logger log = LoggerFactory.getLogger(AuthService.class);
 
     private final JwtUtil jwtUtil;
     private final AuthRepository authRepository;

--- a/src/main/java/com/thekey/stylekeyserver/auth/service/AuthService.java
+++ b/src/main/java/com/thekey/stylekeyserver/auth/service/AuthService.java
@@ -67,7 +67,7 @@ public class AuthService {
         String accessToken = jwtUtil.createToken(authRequestDto.getUser_id());
         String refreshToken = jwtUtil.createRefreshToken(authRequestDto.getUser_id());
 
-        member.get().setRefreshToken(refreshToken);
+        member.get().setRefreshToken(refreshToken.substring(7));
         authRepository.save(member.get());
 
         TokenDto tokenDto = new TokenDto(accessToken, refreshToken);


### PR DESCRIPTION
postman으로 모두 테스트 완료하였고 의도대로 return 되는 것을 확인하였습니다.
1. request, reponse dto에서 유저 아이디를 반환할 때 member_id, user_id가 혼용되고 있어 user_id로 통일했습니다.
2. access token 재발급 시 RTR을 적용했습니다.