### PR TITLE
Fix: 소셜 로그인 시 발급 받은 accessToken을 Header에 넣지 않아도 다른 API 연결되는 문제 해결

### DIFF
--- a/src/main/java/com/thekey/stylekeyserver/global/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/thekey/stylekeyserver/global/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -43,7 +43,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             String token = tokenProvider.createToken(userEmail);
     
             targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
-                    .queryParam("token", token)
+                    .queryParam("token", token.substring(7))
                     .build().toUriString();
         } else if (authentication.getPrincipal() instanceof UserDetails) {
             UserDetails userDetails = (UserDetails) authentication.getPrincipal();

--- a/src/main/java/com/thekey/stylekeyserver/global/security/SecurityConfig.java
+++ b/src/main/java/com/thekey/stylekeyserver/global/security/SecurityConfig.java
@@ -84,7 +84,7 @@ public class SecurityConfig {
                 .requestMatchers("/v3/api-docs/**").permitAll()
                 .requestMatchers("/api/auth/**").permitAll()
                 .requestMatchers("/oauth2/**").permitAll()
-                // .anyRequest().authenticated()
+                .anyRequest().authenticated()
                 .and()
 
                 .oauth2Login()


### PR DESCRIPTION
@JWbase 말씀해주신 문제에 대해 작업 후 postman으로 테스트 해보았을 때 구글 소셜 로그인을 통해 받은 엑세스 토큰이 없는 경우 styleKey의 다른 API 연결을 못하도록 토큰이 없다는 응답 받을 수 있도록 수정했습니다. 