### PR TITLE
Fix: Security에서 회원 정보 가져올 때 이름이 아닌 Email을 기준으로 가져오도록 변경

### DIFF
--- a/src/main/java/com/thekey/stylekeyserver/global/oauth/dto/SessionUser.java
+++ b/src/main/java/com/thekey/stylekeyserver/global/oauth/dto/SessionUser.java
@@ -36,7 +36,7 @@ public class SessionUser implements UserDetails {
 
     @Override
     public String getUsername() {
-        return user.getName();
+        return user.getEmail();
     }
 
     @Override


### PR DESCRIPTION
userRepository에서 email 기준으로 회원 정보를 가져오는 것에 맞추어 패션 테스트 구현 시 security에서 userName을 아이디로 가져오는 것이 아니라 Users entity의 email을 가져오도록 통일 완료했습니다.