### PR TITLE
fix: 테스트 질문지는 로그인 안해도 확인할 수 있도록 security config 수정

### DIFF
--- a/src/main/java/com/thekey/stylekeyserver/global/security/SecurityConfig.java
+++ b/src/main/java/com/thekey/stylekeyserver/global/security/SecurityConfig.java
@@ -85,6 +85,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/auth/**").permitAll()
                 .requestMatchers("/api/oauth/**").permitAll()
                 .requestMatchers("/oauth2/**").permitAll()
+                .requestMatchers("/api/test-question").permitAll()
                 .anyRequest().authenticated()
                 .and()
 

--- a/src/test/java/com/thekey/stylekeyserver/test/repository/TestResultRepositoryTest.java
+++ b/src/test/java/com/thekey/stylekeyserver/test/repository/TestResultRepositoryTest.java
@@ -40,7 +40,7 @@ class TestResultRepositoryTest {
         Users user = userRepository.save(Users.builder()
             .email("test@gmail.com")
             .name("testUser")
-            .password(null)
+            // .password(null)
             .role(Role.USER)
             .provider("Google")
             .build());
@@ -91,7 +91,7 @@ class TestResultRepositoryTest {
         Users user = userRepository.save(Users.builder()
             .email("test@gmail.com")
             .name("testUser")
-            .password(null)
+            // .password(null)
             .role(Role.USER)
             .provider("Google")
             .build());


### PR DESCRIPTION
서비스가 로그인을 유저가 하지 않더라도 테스트 질문을 확인할 수 있어야 하기 때문에 프론트 분들께서 테스트 질문 확인 가능하도록 요청한 것에 대한 pr 입니다. (프론트 분들께서 확인 후 머지)