### PR TITLE
Feat: 관리자페이지 Brand 이미지 파일 S3 이용하여 업로드 하도록 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.1.0'
 	implementation group: 'io.swagger.core.v3', name: 'swagger-core-jakarta', version: '2.2.7'
 
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	
 	compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'

--- a/src/main/java/com/thekey/stylekeyserver/brand/BrandErrorMessage.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/BrandErrorMessage.java
@@ -1,7 +1,9 @@
 package com.thekey.stylekeyserver.brand;
 
 public enum BrandErrorMessage {
-    NOT_FOUND_BRAND("Brand does not found with id: ");
+    NOT_FOUND_BRAND("Brand does not found with id: "),
+    FILE_ALREADY_EXISTS("File already exists in the bucket."),
+    FILE_UPLOAD_FAILED("File upload failed.");
 
     private String msg;
 

--- a/src/main/java/com/thekey/stylekeyserver/brand/controller/BrandAdminController.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/controller/BrandAdminController.java
@@ -47,7 +47,7 @@ public class BrandAdminController {
         try {
             Brand brand = brandAdminService.create(requestDto, imageFile);
             BrandResponse response = BrandResponse.of(brand);
-            return ResponseEntity.ok(ApiResponseDto.of(SuccessType.CREATE_SUCCESS, response));
+            return ResponseEntity.ok(ApiResponseDto.of(SuccessType.SUCCESS, response));
         } catch (FileAlreadyExistsException e) {
             return ResponseEntity.ok(ApiResponseDto.of(ErrorType.FILE_ALREADY_EXISTS));
         } catch (IOException e) {
@@ -59,13 +59,13 @@ public class BrandAdminController {
 
     @GetMapping("/{id}")
     @Operation(summary = "Read One Brand", description = "브랜드 정보 단건 조회")
-    public ResponseEntity<BrandResponse> getBrand(@PathVariable Long id) {
+    public ResponseEntity<ApiResponseDto> getBrand(@PathVariable Long id) {
         Optional<Brand> optional = Optional.ofNullable(brandAdminService.findById(id));
 
         return optional.map(brand -> {
             BrandResponse responseDto = BrandResponse.of(brand);
-            return ResponseEntity.ok(responseDto);
-        }).orElse(ResponseEntity.notFound().build());
+            return ResponseEntity.ok(ApiResponseDto.of(SuccessType.SUCCESS, responseDto));
+        }).orElse(ResponseEntity.ok(ApiResponseDto.of(ErrorType.BAD_REQUEST)));
     }
 
     @GetMapping
@@ -98,7 +98,7 @@ public class BrandAdminController {
 
     @PutMapping("/{id}")
     @Operation(summary = "Update Brand", description = "브랜드 정보 수정")
-    public ResponseEntity<BrandResponse> updateBrand(@PathVariable Long id,
+    public ResponseEntity<ApiResponseDto> updateBrand(@PathVariable Long id,
                                                      @RequestPart BrandRequest requestDto,
                                                      @RequestPart(value = "imageFile", required = false) MultipartFile imageFile)
             throws Exception {
@@ -109,15 +109,15 @@ public class BrandAdminController {
         Optional<Brand> optional = Optional.ofNullable(brandAdminService.update(id, requestDto, imageFile));
         return optional.map(brand -> {
             BrandResponse response = BrandResponse.of(brand);
-            return ResponseEntity.ok(response);
-        }).orElse(ResponseEntity.notFound().build());
+            return ResponseEntity.ok(ApiResponseDto.of(SuccessType.SUCCESS, response));
+        }).orElse(ResponseEntity.ok(ApiResponseDto.of(ErrorType.BAD_REQUEST)));
     }
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Delete Brand", description = "브랜드 정보 삭제")
-    public ResponseEntity<Void> deleteBrand(@PathVariable Long id) {
+    public ResponseEntity<ApiResponseDto> deleteBrand(@PathVariable Long id) {
         brandAdminService.delete(id);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponseDto.of(SuccessType.SUCCESS));
     }
 
 }

--- a/src/main/java/com/thekey/stylekeyserver/brand/controller/BrandAdminController.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/controller/BrandAdminController.java
@@ -19,7 +19,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Brand", description = "Brand API")
 @RestController
@@ -31,8 +33,9 @@ public class BrandAdminController {
 
     @PostMapping
     @Operation(summary = "Create Brand", description = "브랜드 정보 등록")
-    public ResponseEntity<BrandResponse> createBrand(@RequestBody BrandRequest requestDto) {
-        Optional<Brand> optional = Optional.ofNullable(brandAdminService.create(requestDto));
+    public ResponseEntity<BrandResponse> createBrand(@RequestPart BrandRequest requestDto,
+                                                     @RequestPart("imageFile") MultipartFile imageFile) {
+        Optional<Brand> optional = Optional.ofNullable(brandAdminService.create(requestDto, imageFile));
 
         return optional.map(createdBrand -> {
             BrandResponse response = BrandResponse.of(createdBrand);

--- a/src/main/java/com/thekey/stylekeyserver/brand/domain/Brand.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/domain/Brand.java
@@ -51,12 +51,15 @@ public class Brand {
         this.stylePoint = stylePoint;
     }
 
-    public void update(String title, String title_eng, String site_url, String imageUrl,
-                       StylePoint stylePoint) {
+    public void update(String title, String title_eng, String site_url, StylePoint stylePoint) {
         this.title = title;
         this.title_eng = title_eng;
         this.site_url = site_url;
-        this.imageUrl = imageUrl;
         this.stylePoint = stylePoint;
     }
+
+    public void updateImage(String newImageUrl) {
+        this.imageUrl = newImageUrl;
+    }
+
 }

--- a/src/main/java/com/thekey/stylekeyserver/brand/domain/Brand.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/domain/Brand.java
@@ -30,14 +30,11 @@ public class Brand {
     @Column(name = "brand_title_eng")
     private String title_eng;
 
-    @Column(name = "brand_description")
-    private String description;
-
     @Column(name = "brand_site_url")
     private String site_url;
 
-    @Column(name = "brand_image")
-    private String image;
+    @Column(name = "brand_image_url")
+    private String imageUrl;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "style_point_id")
@@ -45,23 +42,21 @@ public class Brand {
     private StylePoint stylePoint;
 
     @Builder
-    public Brand(String title, String title_eng, String description, String site_url, String image,
+    public Brand(String title, String title_eng, String site_url, String imageUrl,
                  StylePoint stylePoint) {
         this.title = title;
         this.title_eng = title_eng;
-        this.description = description;
         this.site_url = site_url;
-        this.image = image;
+        this.imageUrl = imageUrl;
         this.stylePoint = stylePoint;
     }
 
-    public void update(String title, String title_eng, String description, String site_url, String image,
+    public void update(String title, String title_eng, String site_url, String image,
                        StylePoint stylePoint) {
         this.title = title;
         this.title_eng = title_eng;
-        this.description = description;
         this.site_url = site_url;
-        this.image = image;
+        this.imageUrl = imageUrl;
         this.stylePoint = stylePoint;
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/brand/domain/Brand.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/domain/Brand.java
@@ -51,7 +51,7 @@ public class Brand {
         this.stylePoint = stylePoint;
     }
 
-    public void update(String title, String title_eng, String site_url, String image,
+    public void update(String title, String title_eng, String site_url, String imageUrl,
                        StylePoint stylePoint) {
         this.title = title;
         this.title_eng = title_eng;

--- a/src/main/java/com/thekey/stylekeyserver/brand/dto/request/BrandRequest.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/dto/request/BrandRequest.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 
 @Data
@@ -22,36 +23,26 @@ public class BrandRequest {
     @Schema(description = "브랜드 영문 이름", example = "salty pebble")
     private String title_eng;
 
-    @Schema(description = "브랜드 설명", example = "솔티페블은 일정한 형식이나 틀을 갖추지 않은 조약돌의 본질을 바라보고 비정형화적인 이미지에 맞춰 시대를 유동하는 컨템포러리 브랜드이다.")
-    private String description;
-
     @Schema(description = "브랜드 웹 사이트 URL", example = "https://www.saltypebble.com/")
     private String site_url;
-
-    @Schema(description = "브랜드 이미지 URL", example = "brand_image_url")
-    private String image;
 
     @Schema(description = "스타일 포인트 ID", example = "1")
     private Long stylePointId;
 
     @Builder
-    public BrandRequest(String title, String title_eng, String description, String site_url, String image,
-                        Long stylePointId) {
+    public BrandRequest(String title, String title_eng, String site_url, Long stylePointId) {
         this.title = title;
         this.title_eng = title_eng;
-        this.description = description;
         this.site_url = site_url;
-        this.image = image;
         this.stylePointId = stylePointId;
     }
 
-    public Brand toEntity(StylePoint stylePoint) {
+    public Brand toEntity(StylePoint stylePoint, String imageUrl) {
         return Brand.builder()
                 .title(this.title)
                 .title_eng(this.title_eng)
-                .description(this.description)
                 .site_url(this.site_url)
-                .image(this.image)
+                .imageUrl(imageUrl)
                 .stylePoint(stylePoint)
                 .build();
     }

--- a/src/main/java/com/thekey/stylekeyserver/brand/dto/response/BrandResponse.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/dto/response/BrandResponse.java
@@ -22,27 +22,23 @@ public class BrandResponse {
     @Schema(description = "브랜드 영문 이름", example = "salty pebble")
     private String title_eng;
 
-    @Schema(description = "브랜드 설명", example = "솔티페블은 일정한 형식이나 틀을 갖추지 않은 조약돌의 본질을 바라보고 비정형화적인 이미지에 맞춰 시대를 유동하는 컨템포러리 브랜드이다.")
-    private String description;
-
     @Schema(description = "브랜드 웹 사이트 URL", example = "https://www.saltypebble.com/")
     private String site_url;
 
     @Schema(description = "브랜드 이미지 URL", example = "brand_image_url")
-    private String image;
+    private String imageUrl;
 
     @Schema(description = "스타일 포인트 ID", example = "1")
     private Long stylePointId;
 
     @Builder
-    public BrandResponse(Long id, String title, String title_eng, String description, String site_url, String image,
+    public BrandResponse(Long id, String title, String title_eng, String description, String site_url, String imageUrl,
                          Long stylePointId) {
         this.id = id;
         this.title = title;
         this.title_eng = title_eng;
-        this.description = description;
         this.site_url = site_url;
-        this.image = image;
+        this.imageUrl = imageUrl;
         this.stylePointId = stylePointId;
     }
 
@@ -51,9 +47,8 @@ public class BrandResponse {
                 .id(brand.getId())
                 .title(brand.getTitle())
                 .title_eng(brand.getTitle_eng())
-                .description(brand.getDescription())
                 .site_url(brand.getSite_url())
-                .image(brand.getImage())
+                .imageUrl(brand.getImageUrl())
                 .stylePointId(brand.getStylePoint().getId())
                 .build();
     }

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminService.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminService.java
@@ -2,12 +2,13 @@ package com.thekey.stylekeyserver.brand.service;
 
 import com.thekey.stylekeyserver.brand.domain.Brand;
 import com.thekey.stylekeyserver.brand.dto.request.BrandRequest;
+import java.nio.file.FileAlreadyExistsException;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface BrandAdminService {
 
-    Brand create(BrandRequest requestDto, MultipartFile imageFile);
+    Brand create(BrandRequest requestDto, MultipartFile imageFile) throws FileAlreadyExistsException;
 
     Brand findById(Long id);
 
@@ -15,7 +16,7 @@ public interface BrandAdminService {
 
     List<Brand> findByStylePointId(Long id);
 
-    Brand update(Long id, BrandRequest requestDto);
+    Brand update(Long id, BrandRequest requestDto, MultipartFile imageFile) throws Exception;
 
     void delete(Long id);
 

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminService.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminService.java
@@ -8,7 +8,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface BrandAdminService {
 
-    Brand create(BrandRequest requestDto, MultipartFile imageFile) throws FileAlreadyExistsException;
+    Brand create(BrandRequest requestDto, MultipartFile imageFile) throws Exception;
 
     Brand findById(Long id);
 

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminService.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminService.java
@@ -3,10 +3,11 @@ package com.thekey.stylekeyserver.brand.service;
 import com.thekey.stylekeyserver.brand.domain.Brand;
 import com.thekey.stylekeyserver.brand.dto.request.BrandRequest;
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface BrandAdminService {
 
-    Brand create(BrandRequest requestDto);
+    Brand create(BrandRequest requestDto, MultipartFile imageFile);
 
     Brand findById(Long id);
 

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
@@ -57,7 +57,7 @@ public class BrandAdminServiceImpl implements BrandAdminService {
 
         String oldImageUrl = brand.getImageUrl();
         if (oldImageUrl != null) {
-            s3Service.deleteFile(oldImageUrl);
+            s3Service.deleteFile(oldImageUrl, "brand");
             String newImageUrl = s3Service.uploadFile(imageFile, "brand");
             brand.updateImage(newImageUrl);
         }
@@ -75,7 +75,7 @@ public class BrandAdminServiceImpl implements BrandAdminService {
         Brand brand = brandRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(BrandErrorMessage.NOT_FOUND_BRAND.get() + id));
         String imageFile = brand.getImageUrl();
-        s3Service.deleteFile(imageFile);
+        s3Service.deleteFile(imageFile, "brand");
         brandRepository.deleteById(id);
     }
 

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
@@ -4,6 +4,7 @@ import com.thekey.stylekeyserver.brand.BrandErrorMessage;
 import com.thekey.stylekeyserver.brand.domain.Brand;
 import com.thekey.stylekeyserver.brand.dto.request.BrandRequest;
 import com.thekey.stylekeyserver.brand.repository.BrandRepository;
+import com.thekey.stylekeyserver.s3.S3Service;
 import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
 import com.thekey.stylekeyserver.stylepoint.service.StylePointAdminService;
 import jakarta.persistence.EntityNotFoundException;
@@ -11,6 +12,7 @@ import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -19,11 +21,14 @@ public class BrandAdminServiceImpl implements BrandAdminService {
 
     private final BrandRepository brandRepository;
     private final StylePointAdminService stylePointAdminService;
+    private final S3Service s3Service;
 
     @Override
-    public Brand create(BrandRequest requestDto) {
+    public Brand create(BrandRequest requestDto, MultipartFile imageFile) {
         StylePoint stylePoint = stylePointAdminService.findById(requestDto.getStylePointId());
-        return brandRepository.save(requestDto.toEntity(stylePoint));
+        String imageUrl = s3Service.uploadFile(imageFile, "brand");
+
+        return brandRepository.save(requestDto.toEntity(stylePoint, imageUrl));
     }
 
     @Override
@@ -48,14 +53,14 @@ public class BrandAdminServiceImpl implements BrandAdminService {
         Brand brand = brandRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(BrandErrorMessage.NOT_FOUND_BRAND.get() + id));
 
-        StylePoint stylePoint = stylePointAdminService.findById(requestDto.getStylePointId());
-
-        brand.update(requestDto.getTitle(),
-                requestDto.getTitle_eng(),
-                requestDto.getDescription(),
-                requestDto.getSite_url(),
-                requestDto.getImage(),
-                requestDto.toEntity(stylePoint).getStylePoint());
+//        StylePoint stylePoint = stylePointAdminService.findById(requestDto.getStylePointId());
+//
+//        brand.update(requestDto.getTitle(),
+//                requestDto.getTitle_eng(),
+//                requestDto.getDescription(),
+//                requestDto.getSite_url(),
+//                requestDto.getImage(),
+//                requestDto.toEntity(stylePoint).getStylePoint());
 
         return brand;
     }

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
@@ -63,8 +63,6 @@ public class BrandAdminServiceImpl implements BrandAdminService {
         StylePoint stylePoint = stylePointAdminService.findById(requestDto.getStylePointId());
 
         String oldImageUrl = brand.getImageUrl();
-        System.out.println("========================");
-        System.out.println(oldImageUrl);
         if(oldImageUrl != null) {
             s3Service.deleteFile(oldImageUrl);
         }
@@ -79,8 +77,6 @@ public class BrandAdminServiceImpl implements BrandAdminService {
 
         return brand;
     }
-
-
     @Override
     public void delete(Long id) {
         brandRepository.deleteById(id);

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
@@ -4,13 +4,11 @@ import com.thekey.stylekeyserver.brand.BrandErrorMessage;
 import com.thekey.stylekeyserver.brand.domain.Brand;
 import com.thekey.stylekeyserver.brand.dto.request.BrandRequest;
 import com.thekey.stylekeyserver.brand.repository.BrandRepository;
-import com.thekey.stylekeyserver.s3.S3ErrorMessage;
 import com.thekey.stylekeyserver.s3.S3Service;
 import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
 import com.thekey.stylekeyserver.stylepoint.service.StylePointAdminService;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
-import java.nio.file.FileAlreadyExistsException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,14 +24,9 @@ public class BrandAdminServiceImpl implements BrandAdminService {
     private final S3Service s3Service;
 
     @Override
-    public Brand create(BrandRequest requestDto, MultipartFile imageFile) throws FileAlreadyExistsException {
+    public Brand create(BrandRequest requestDto, MultipartFile imageFile) throws Exception {
         String imageUrl = null;
-        try {
-           imageUrl = s3Service.uploadFile(imageFile, "brand");
-        } catch (Exception e) {
-            throw new RuntimeException(S3ErrorMessage.FILE_UPLOAD_FAILED.get());
-        }
-
+        imageUrl = s3Service.uploadFile(imageFile, "brand");
         StylePoint stylePoint = stylePointAdminService.findById(requestDto.getStylePointId());
         return brandRepository.save(requestDto.toEntity(stylePoint, imageUrl));
     }
@@ -62,23 +55,28 @@ public class BrandAdminServiceImpl implements BrandAdminService {
 
         StylePoint stylePoint = stylePointAdminService.findById(requestDto.getStylePointId());
 
-        String oldImageUrl = brand.getImageUrl();
-        if(oldImageUrl != null) {
-            s3Service.deleteFile(oldImageUrl);
+        if(imageFile != null) {
+            String newImageUrl = s3Service.uploadFile(imageFile, "brand");
+            if(brand.getImageUrl() != null) {
+                s3Service.deleteFile(brand.getImageUrl());
+            }
+            brand.updateImage(newImageUrl);
         }
-
-        String newImageUrl = s3Service.uploadFile(imageFile, "brand");
 
         brand.update(requestDto.getTitle(),
                 requestDto.getTitle_eng(),
                 requestDto.getSite_url(),
-                newImageUrl,
                 stylePoint);
 
         return brand;
     }
+
     @Override
     public void delete(Long id) {
+        Brand brand = brandRepository.findById(id)
+                        .orElseThrow(() -> new EntityNotFoundException(BrandErrorMessage.NOT_FOUND_BRAND.get() + id));
+        String imageFile = brand.getImageUrl();
+        s3Service.deleteFile(imageFile);
         brandRepository.deleteById(id);
     }
 

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
@@ -55,11 +55,10 @@ public class BrandAdminServiceImpl implements BrandAdminService {
 
         StylePoint stylePoint = stylePointAdminService.findById(requestDto.getStylePointId());
 
-        if(imageFile != null) {
+        String oldImageUrl = brand.getImageUrl();
+        if (oldImageUrl != null) {
+            s3Service.deleteFile(oldImageUrl);
             String newImageUrl = s3Service.uploadFile(imageFile, "brand");
-            if(brand.getImageUrl() != null) {
-                s3Service.deleteFile(brand.getImageUrl());
-            }
             brand.updateImage(newImageUrl);
         }
 
@@ -74,7 +73,7 @@ public class BrandAdminServiceImpl implements BrandAdminService {
     @Override
     public void delete(Long id) {
         Brand brand = brandRepository.findById(id)
-                        .orElseThrow(() -> new EntityNotFoundException(BrandErrorMessage.NOT_FOUND_BRAND.get() + id));
+                .orElseThrow(() -> new EntityNotFoundException(BrandErrorMessage.NOT_FOUND_BRAND.get() + id));
         String imageFile = brand.getImageUrl();
         s3Service.deleteFile(imageFile);
         brandRepository.deleteById(id);

--- a/src/main/java/com/thekey/stylekeyserver/global/response/ApiResponseDto.java
+++ b/src/main/java/com/thekey/stylekeyserver/global/response/ApiResponseDto.java
@@ -1,5 +1,7 @@
 package com.thekey.stylekeyserver.global.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,21 +11,23 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ApiResponseDto {
+public class ApiResponseDto<T> {
     private int statusCode;
     private String message;
-    private Object data;
 
-    public static ApiResponseDto of(ErrorType errorType, Object data) {
-        return ApiResponseDto.builder()
+    @JsonInclude(Include.NON_NULL)
+    private T data;
+
+    public static <T> ApiResponseDto of(ErrorType errorType, T data) {
+        return ApiResponseDto.<T>builder()
                 .statusCode(errorType.getStatusCode())
                 .message(errorType.getMessage())
                 .data(data)
                 .build();
     }
 
-    public static ApiResponseDto of(SuccessType successType, Object data) {
-        return ApiResponseDto.builder()
+    public static <T> ApiResponseDto of(SuccessType successType, T data) {
+        return ApiResponseDto.<T>builder()
                 .statusCode(successType.getStatusCode())
                 .message(successType.getMessage())
                 .data(data)

--- a/src/main/java/com/thekey/stylekeyserver/global/response/ErrorType.java
+++ b/src/main/java/com/thekey/stylekeyserver/global/response/ErrorType.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorType {
 
+    /* 로그인 관련 에러 메시지 */
     NOT_VALID_REQUEST(400,  "유효하지 않은 요청입니다."),
     NOT_VALID_TOKEN(400,"유효한 토큰이 아닙니다."),
     TOKEN_NOT_FOUND(400,  "토큰이 없습니다."),
@@ -16,7 +17,12 @@ public enum ErrorType {
     USER_NICKNAME_EXIST(400, "이미 존재하는 닉네임입니다."),
     USER_ACCOUNT_NOT_EXIST(400,  "계정 정보가 존재하지 않습니다."),
     USER_NOT_FOUND(400, "사용자가 존재하지 않습니다."),
-    PASSWORD_MISMATCH(400,  "비밀번호가 일치하지 않습니다.");
+    PASSWORD_MISMATCH(400,  "비밀번호가 일치하지 않습니다."),
+
+    /* 패션 컨텐츠 관련 에러 메시지 */
+    FILE_UPLOAD_FAILED(400, "이미지 등록이 실패하였습니다."),
+    FILE_ALREADY_EXISTS(400, "이미 등록된 이미지입니다."),
+    INVALID_IMAGE_FORMAT(400, "올바른 형식의 이미지가 아닙니다.");
 
     private final int statusCode;
     private final String message;

--- a/src/main/java/com/thekey/stylekeyserver/global/response/ErrorType.java
+++ b/src/main/java/com/thekey/stylekeyserver/global/response/ErrorType.java
@@ -8,6 +8,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorType {
 
+    /* 기본 요청 에러 메시지 */
+    BAD_REQUEST(201, "불가능한 요청입니다."),
+
     /* 로그인 관련 에러 메시지 */
     NOT_VALID_REQUEST(400,  "유효하지 않은 요청입니다."),
     NOT_VALID_TOKEN(400,"유효한 토큰이 아닙니다."),

--- a/src/main/java/com/thekey/stylekeyserver/global/response/SuccessType.java
+++ b/src/main/java/com/thekey/stylekeyserver/global/response/SuccessType.java
@@ -7,12 +7,15 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SuccessType {
 
+    /* 로그인 관련 성공 반환 메시지 */
     SIGN_UP_SUCCESS(200, "회원 가입에 성공했습니다."),
     LOG_IN_SUCCESS(200, "로그인되었습니다."),
     CHANGE_PASSWORD(200, "비밀번호가 변경되었습니다."),
     USER_EXIST(200, "존재하는 회원입니다."),
-    REISSUE_SUCCESS(200, "토큰 재발급이 성공적으로 되었습니다.");
+    REISSUE_SUCCESS(200, "토큰 재발급이 성공적으로 되었습니다."),
 
+    /* 패션 컨텐츠 관련 성공 반환 메시지 */
+    CREATE_SUCCESS(200, "등록이 성공적으로 완료되었습니다.");
 
     private final int statusCode;
     private final String message;

--- a/src/main/java/com/thekey/stylekeyserver/global/response/SuccessType.java
+++ b/src/main/java/com/thekey/stylekeyserver/global/response/SuccessType.java
@@ -7,15 +7,15 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SuccessType {
 
+    /* 기본 요청 성공 메시지 */
+    SUCCESS(200, "API 요청이 성공했습니다."),
+
     /* 로그인 관련 성공 반환 메시지 */
     SIGN_UP_SUCCESS(200, "회원 가입에 성공했습니다."),
     LOG_IN_SUCCESS(200, "로그인되었습니다."),
     CHANGE_PASSWORD(200, "비밀번호가 변경되었습니다."),
     USER_EXIST(200, "존재하는 회원입니다."),
-    REISSUE_SUCCESS(200, "토큰 재발급이 성공적으로 되었습니다."),
-
-    /* 패션 컨텐츠 관련 성공 반환 메시지 */
-    CREATE_SUCCESS(200, "등록이 성공적으로 완료되었습니다.");
+    REISSUE_SUCCESS(200, "토큰 재발급이 성공적으로 되었습니다.");
 
     private final int statusCode;
     private final String message;

--- a/src/main/java/com/thekey/stylekeyserver/global/security/SecurityConfig.java
+++ b/src/main/java/com/thekey/stylekeyserver/global/security/SecurityConfig.java
@@ -27,7 +27,7 @@ import com.thekey.stylekeyserver.global.oauth.OAuth2AuthenticationFailureHandler
 import com.thekey.stylekeyserver.global.oauth.OAuth2AuthenticationSuccessHandler;
 
 @Configuration
-@EnableWebSecurity
+//@EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -66,7 +66,7 @@ public class SecurityConfig {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer(){
         return (web) -> web.ignoring()
-               .requestMatchers(PathRequest.toH2Console()) 
+               .requestMatchers(PathRequest.toH2Console())
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
     }
 
@@ -74,37 +74,39 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception{
 
         http.cors();
-        http.csrf().disable();                 
-        http.formLogin().disable();           
+        http.csrf().disable();
+        http.formLogin().disable();
 
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
         http.authorizeRequests()
-                .requestMatchers("/swagger-ui/**").permitAll()
-                .requestMatchers("/v3/api-docs/**").permitAll()
-                .requestMatchers("/api/auth/**").permitAll()
-                .requestMatchers("/api/oauth/**").permitAll()
-                .requestMatchers("/oauth2/**").permitAll()
-                .requestMatchers("/api/test-question").permitAll()
-                .anyRequest().authenticated()
-                .and()
+//                .requestMatchers("/swagger-ui/**").permitAll()
+//                .requestMatchers("/v3/api-docs/**").permitAll()
+//                .requestMatchers("/api/auth/**").permitAll()
+//                .requestMatchers("/api/oauth/**").permitAll()
+//                .requestMatchers("/oauth2/**").permitAll()
+//                .requestMatchers("/api/test-question").permitAll()
+//                .anyRequest().authenticated()
+//                .and()
+                .requestMatchers("/**").permitAll()
+                .anyRequest().authenticated();
 
-                .oauth2Login()
-                    .authorizationEndpoint().baseUri("/oauth2/authorize")
-                    .authorizationRequestRepository(cookieOAuth2AuthorizationRequestRepository())
-                .and()
-                    .redirectionEndpoint()
-                    .baseUri("/login/oauth2/code/**") // /login/oauth2/code/** // /oauth/callback/kakao
-                .and()
-                    .userInfoEndpoint().userService(customOAuth2UserService)
-                .and()
-                    .successHandler(oAuth2AuthenticationSuccessHandler)
-                    .failureHandler(oAuth2AuthenticationFailureHandler)
-                    
-                
-
-                .and().exceptionHandling().authenticationEntryPoint(new CustomAuthenticationEntryPoint())
-                .and().addFilterBefore(new JwtAuthFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+//                .oauth2Login()
+//                    .authorizationEndpoint().baseUri("/oauth2/authorize")
+//                    .authorizationRequestRepository(cookieOAuth2AuthorizationRequestRepository())
+//                .and()
+//                    .redirectionEndpoint()
+//                    .baseUri("/login/oauth2/code/**") // /login/oauth2/code/** // /oauth/callback/kakao
+//                .and()
+//                    .userInfoEndpoint().userService(customOAuth2UserService)
+//                .and()
+//                    .successHandler(oAuth2AuthenticationSuccessHandler)
+//                    .failureHandler(oAuth2AuthenticationFailureHandler)
+//
+//
+//
+//                .and().exceptionHandling().authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+//                .and().addFilterBefore(new JwtAuthFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/thekey/stylekeyserver/s3/S3Config.java
+++ b/src/main/java/com/thekey/stylekeyserver/s3/S3Config.java
@@ -1,0 +1,34 @@
+package com.thekey.stylekeyserver.s3;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 s3client() {
+        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .withRegion(region)
+                .build();
+    }
+
+}

--- a/src/main/java/com/thekey/stylekeyserver/s3/S3ErrorMessage.java
+++ b/src/main/java/com/thekey/stylekeyserver/s3/S3ErrorMessage.java
@@ -2,7 +2,8 @@ package com.thekey.stylekeyserver.s3;
 
 public enum S3ErrorMessage {
     FILE_UPLOAD_FAILED("File upload failed"),
-    FILE_ALREADY_EXISTS("File already exists");
+    FILE_ALREADY_EXISTS("File already exists"),
+    URL_DECODING_FAILED("URL decoding failed:");
     private String msg;
 
     S3ErrorMessage(String msg) {

--- a/src/main/java/com/thekey/stylekeyserver/s3/S3ErrorMessage.java
+++ b/src/main/java/com/thekey/stylekeyserver/s3/S3ErrorMessage.java
@@ -1,0 +1,15 @@
+package com.thekey.stylekeyserver.s3;
+
+public enum S3ErrorMessage {
+    FILE_UPLOAD_FAILED("File upload failed"),
+    FILE_ALREADY_EXISTS("File already exists");
+    private String msg;
+
+    S3ErrorMessage(String msg) {
+        this.msg = msg;
+    }
+
+    public String get() {
+        return msg;
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/s3/S3Service.java
+++ b/src/main/java/com/thekey/stylekeyserver/s3/S3Service.java
@@ -1,9 +1,11 @@
 package com.thekey.stylekeyserver.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
@@ -29,23 +31,18 @@ public class S3Service {
     @Value("${cloud.aws.s3.item}")
     private String itemFolder;
 
-    public String uploadFile(MultipartFile file, String imageType) throws Exception {
-        try {
-            String folderName = getFolderName(imageType);
-            String fileName = generateFileName(file, folderName);
+    public String uploadFile(MultipartFile file, String imageType) throws IOException {
+        String folderName = getFolderName(imageType);
+        String fileName = generateFileName(file, folderName);
 
-            if(s3Client.doesObjectExist(bucket, fileName)) {
-                throw new FileAlreadyExistsException(S3ErrorMessage.FILE_ALREADY_EXISTS.get());
-            }
-
-            File convertedFile = convertMultiPartToFile(file);
-            uploadFileTos3bucket(fileName, convertedFile);
-            return getFileUrl(fileName);
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new Exception(S3ErrorMessage.FILE_UPLOAD_FAILED.get());
+        // 동일한 이름의 파일이 이미 존재하는지 확인한다.
+        if (s3Client.doesObjectExist(bucket, fileName)) {
+            throw new FileAlreadyExistsException(S3ErrorMessage.FILE_ALREADY_EXISTS.get());
         }
+
+        File convertedFile = convertMultiPartToFile(file);
+        uploadFileTos3bucket(fileName, convertedFile);
+        return getFileUrl(fileName);
     }
 
 
@@ -89,18 +86,15 @@ public class S3Service {
         if (s3Client.doesObjectExist(bucket, fileName)) {
             throw new FileAlreadyExistsException(S3ErrorMessage.FILE_ALREADY_EXISTS.get() + fileName);
         }
-        s3Client.putObject(new PutObjectRequest(bucket, fileName, file));
 
+        s3Client.putObject(new PutObjectRequest(bucket, fileName, file));
         // s3에 객체 생성 시 임시 파일이 자동으로 남는다.
-        // 이를 따로 삭제하는 로직
-        boolean isDeleted = file.delete();
-        if (!isDeleted) {
-            throw new RuntimeException();
+        if (!file.delete()) {
+            throw new RuntimeException(S3ErrorMessage.FILE_UPLOAD_FAILED.get());
         }
     }
 
     private String getFileUrl(String fileName) {
         return s3Client.getUrl(bucket, fileName).toString();
     }
-
 }

--- a/src/main/java/com/thekey/stylekeyserver/s3/S3Service.java
+++ b/src/main/java/com/thekey/stylekeyserver/s3/S3Service.java
@@ -1,6 +1,7 @@
 package com.thekey.stylekeyserver.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -28,7 +29,7 @@ public class S3Service {
     @Value("${cloud.aws.s3.item}")
     private String itemFolder;
 
-    public String uploadFile(MultipartFile file, String imageType) {
+    public String uploadFile(MultipartFile file, String imageType) throws Exception {
         try {
             String folderName = getFolderName(imageType);
             String fileName = generateFileName(file, folderName);
@@ -41,12 +42,16 @@ public class S3Service {
             uploadFileTos3bucket(fileName, convertedFile);
             return getFileUrl(fileName);
 
-        } catch (FileAlreadyExistsException e) {
-            return S3ErrorMessage.FILE_ALREADY_EXISTS.get();
         } catch (Exception e) {
             e.printStackTrace();
-            return S3ErrorMessage.FILE_UPLOAD_FAILED.get();
+            throw new Exception(S3ErrorMessage.FILE_UPLOAD_FAILED.get());
         }
+    }
+
+
+    public void deleteFile(String fileUrl) {
+        String fileName = fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
+        s3Client.deleteObject(new DeleteObjectRequest(bucket, fileName));
     }
 
     private String getFolderName(String imageType) {

--- a/src/main/java/com/thekey/stylekeyserver/s3/S3Service.java
+++ b/src/main/java/com/thekey/stylekeyserver/s3/S3Service.java
@@ -51,10 +51,9 @@ public class S3Service {
         return getFileUrl(fileName);
     }
 
-    public void deleteFile(String fileUrl) {
+    public boolean deleteFile(String fileUrl, String imageType) {
         try {
-            String bucketName = "stylekeybucket";  // 설정에서 제공된 버킷 이름
-            String folderName = "brand";  // 설정에서 제공된 폴더 이름
+            String folderName = getFolderName(imageType).replaceAll("/", ""); // 설정에서 제공된 폴더 이름
 
             URL url = new URL(fileUrl);
             String fileName = url.getPath().substring(1);  // 앞에 있는 '/' 제거
@@ -62,19 +61,16 @@ public class S3Service {
             String fullFileName = folderName + fileName.substring(fileName.indexOf("/"));
 
             String decodedFullFileName = URLDecoder.decode(fullFileName, StandardCharsets.UTF_8.toString());
-            s3Client.deleteObject(new DeleteObjectRequest(bucketName, decodedFullFileName));
+            s3Client.deleteObject(new DeleteObjectRequest(bucket, decodedFullFileName));
+            return true;
+
         } catch (AmazonServiceException e) {
-            System.err.println(e.getErrorMessage());
+            return false;
         } catch (UnsupportedEncodingException | MalformedURLException e) {
-            System.err.println("URL decoding failed: " + e.getMessage());
+            System.out.println(S3ErrorMessage.URL_DECODING_FAILED);
+           return false;
         }
     }
-
-
-//    public void deleteFile(String fileUrl, String imageType) {
-//        String fileName = fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
-//        s3Client.deleteObject(new DeleteObjectRequest(bucket, fileName));
-//    }
 
     private String getFolderName(String imageType) {
         switch (imageType) {

--- a/src/main/java/com/thekey/stylekeyserver/s3/S3Service.java
+++ b/src/main/java/com/thekey/stylekeyserver/s3/S3Service.java
@@ -1,0 +1,101 @@
+package com.thekey.stylekeyserver.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+    private final AmazonS3 s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.s3.brand}")
+    private String brandFolder;
+
+    @Value("${cloud.aws.s3.coordinateLook}")
+    private String coordinateLookFolder;
+
+    @Value("${cloud.aws.s3.item}")
+    private String itemFolder;
+
+    public String uploadFile(MultipartFile file, String imageType) {
+        try {
+            String folderName = getFolderName(imageType);
+            String fileName = generateFileName(file, folderName);
+
+            if(s3Client.doesObjectExist(bucket, fileName)) {
+                throw new FileAlreadyExistsException(S3ErrorMessage.FILE_ALREADY_EXISTS.get());
+            }
+
+            File convertedFile = convertMultiPartToFile(file);
+            uploadFileTos3bucket(fileName, convertedFile);
+            return getFileUrl(fileName);
+
+        } catch (FileAlreadyExistsException e) {
+            return S3ErrorMessage.FILE_ALREADY_EXISTS.get();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return S3ErrorMessage.FILE_UPLOAD_FAILED.get();
+        }
+    }
+
+    private String getFolderName(String imageType) {
+        switch (imageType) {
+            case "brand":
+                return brandFolder;
+            case "coordinateLook":
+                return coordinateLookFolder;
+            case "item":
+                return itemFolder;
+            default:
+                return "";
+        }
+    }
+
+    private File convertMultiPartToFile(MultipartFile file) throws IOException {
+        File convertedFile = new File(file.getOriginalFilename());
+
+        // FileOutputStream을 닫아야 파일이 닫힘
+        // 만약 파일이 계속 열러있으면 삭제가 안 될 수 있음
+        try (FileOutputStream fos = new FileOutputStream(convertedFile)) {
+            fos.write(file.getBytes());
+        }
+        return convertedFile;
+    }
+
+    private String generateFileName(MultipartFile multiPart, String folderName) {
+        return new StringBuilder()
+                .append(folderName)
+                .append(multiPart.getOriginalFilename())
+                .toString();
+    }
+
+    private void uploadFileTos3bucket(String fileName, File file) throws FileAlreadyExistsException {
+        if (s3Client.doesObjectExist(bucket, fileName)) {
+            throw new FileAlreadyExistsException(S3ErrorMessage.FILE_ALREADY_EXISTS.get() + fileName);
+        }
+        s3Client.putObject(new PutObjectRequest(bucket, fileName, file));
+
+        // s3에 객체 생성 시 임시 파일이 자동으로 남는다.
+        // 이를 따로 삭제하는 로직
+        boolean isDeleted = file.delete();
+        if (!isDeleted) {
+            throw new RuntimeException();
+        }
+    }
+
+    private String getFileUrl(String fileName) {
+        return s3Client.getUrl(bucket, fileName).toString();
+    }
+
+}


### PR DESCRIPTION
관리자페이지에서 브랜드 이미지 파일을 업로드 하면, 자동으로 AWS S3에 업로드 되며, 해당 객체 URL를 반환 받아 디비에 저장하는 로직을 추가했습니다. 일단 현재 브랜드 도메인부터 피드백을 받고 코드 수정 후, 나머지 코디룩과 아이템 로직을 구현해보겠습니다.

아래 사항을 중점으로 코드 봐주시면 감사하겠습니다. 피드백 부탁드려요!! 😅

### 이미지 등록 시
* 이미 같은 이름의 파일이 등록되어 있는 경우, 예외를 발생시키고 브랜드 생성 자체를 중단하도록 구현했습니다. 
* 브랜드, 코디룩, 아이템의 폴더를 다음과 같이 분리하여 관리할 수 있도록 `imageType` 을 입력 받고, 해당 위치에 파일을 등록하도록 했습니다.
* 이미지 파일의 형식이 잘못되거나, 입력값이 없을 경우의 예외를 처리하였습니다.

![스크린샷 2024-02-22 오전 12 01 26](https://github.com/styleKey/back/assets/62649762/d94b2ac7-32e0-42b5-a8cd-e33ca4672094)

### 이미지 수정 시
* 수정하고 싶은 이미지를 찾고, 이를 삭제하고 다시 새로운 파일을 등록합니다. 이때 새로운 이미지로 브랜드의 이미지 URL이 바뀌는 것은 확인했지만 S3 버킷 내에 파일은 삭제되지 않고 그대로 남아있습니다. 이 부분의 경우 S3 버킷의 버전 관리 설정을 따로 확인해봐야할 것 같습니다. S3 버킷의 버전 관리 기능이 완전히 꺼져 있는 상태에서만 객체를 삭제한다고 하네요.
--> 이 부분은 기존 객체 URL 이름을 가져오는 부분을 수정하여 해결했습니다.