### PR TITLE
Refactor: 관리자페이지 Brand 관리 전체 리팩토링

### DIFF
--- a/src/main/java/com/thekey/stylekeyserver/brand/controller/BrandAdminController.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/controller/BrandAdminController.java
@@ -4,6 +4,8 @@ import com.thekey.stylekeyserver.brand.domain.Brand;
 import com.thekey.stylekeyserver.brand.dto.request.BrandRequest;
 import com.thekey.stylekeyserver.brand.dto.response.BrandResponse;
 import com.thekey.stylekeyserver.brand.service.BrandAdminService;
+import com.thekey.stylekeyserver.common.ApiResponse;
+import com.thekey.stylekeyserver.common.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -11,15 +13,15 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Brand", description = "Brand API")
 @RestController
@@ -31,74 +33,69 @@ public class BrandAdminController {
 
     @PostMapping
     @Operation(summary = "Create Brand", description = "브랜드 정보 등록")
-    public ResponseEntity<BrandResponse> createBrand(@RequestBody BrandRequest requestDto) {
-        Optional<Brand> optional = Optional.ofNullable(brandAdminService.create(requestDto));
+    public ApiResponse createBrand(@RequestPart BrandRequest requestDto,
+                                   @RequestPart("imageFile") MultipartFile imageFile) throws Exception {
 
-        return optional.map(createdBrand -> {
-            BrandResponse response = BrandResponse.of(createdBrand);
-            return ResponseEntity.ok(response);
-        }).orElse(ResponseEntity.notFound().build());
+        if (imageFile == null || imageFile.isEmpty()) {
+            return ApiResponse.fail(HttpStatus.BAD_REQUEST, ErrorCode.INVALID_IMAGE_FORMAT.getMessage());
+        }
+        brandAdminService.create(requestDto, imageFile);
+        return ApiResponse.success();
     }
 
     @GetMapping("/{id}")
     @Operation(summary = "Read One Brand", description = "브랜드 정보 단건 조회")
-    public ResponseEntity<BrandResponse> getBrand(@PathVariable Long id) {
+    public ApiResponse getBrand(@PathVariable Long id) {
         Optional<Brand> optional = Optional.ofNullable(brandAdminService.findById(id));
 
         return optional.map(brand -> {
-            BrandResponse responseDto = BrandResponse.of(brand);
-            return ResponseEntity.ok(responseDto);
-        }).orElse(ResponseEntity.notFound().build());
+            BrandResponse response = BrandResponse.of(brand);
+            return ApiResponse.success(response);
+        }).orElse(ApiResponse.fail(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getMessage()));
     }
 
     @GetMapping
     @Operation(summary = "Read All Brands", description = "브랜드 정보 전체 조회")
-    public ResponseEntity<List<BrandResponse>> getBrands() {
+    public ApiResponse getBrands() {
         List<Brand> brands = brandAdminService.findAll();
-        List<BrandResponse> brandDtos = brands.stream()
+        List<BrandResponse> response = brands.stream()
                 .map(BrandResponse::of)
                 .collect(Collectors.toList());
 
-        return Optional.of(brandDtos)
-                .filter(list -> !list.isEmpty())
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.status(HttpStatus.NO_CONTENT).body(brandDtos));
+        return ApiResponse.success(response);
     }
 
     @GetMapping("style-points/{id}")
     @Operation(summary = "Read All Brands By StylePointId", description = "스타일포인트 ID에 해당하는 브랜드 목록 전체 조회")
-    public ResponseEntity<List<BrandResponse>> getBrandsByStylePointId(@PathVariable Long id) {
+    public ApiResponse<List<BrandResponse>> getBrandsByStylePointId(@PathVariable Long id) {
         List<Brand> brands = brandAdminService.findByStylePointId(id);
-        List<BrandResponse> brandDtos = brands.stream()
+        List<BrandResponse> response = brands.stream()
                 .map(BrandResponse::of)
                 .collect(Collectors.toList());
 
-        return Optional.of(brandDtos)
-                .filter(list -> !list.isEmpty())
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.status(HttpStatus.NO_CONTENT).body(brandDtos));
+        return ApiResponse.success(response);
     }
 
     @PutMapping("/{id}")
     @Operation(summary = "Update Brand", description = "브랜드 정보 수정")
-    public ResponseEntity<BrandResponse> updateBrand(@PathVariable Long id,
-                                                     @RequestBody BrandRequest requestDto) {
+    public ApiResponse updateBrand(@PathVariable Long id,
+                                   @RequestPart BrandRequest requestDto,
+                                   @RequestPart(value = "imageFile", required = false) MultipartFile imageFile)
+            throws Exception {
         if (id == null) {
-            return ResponseEntity.badRequest().build();
+            return ApiResponse.fail(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getMessage());
         }
 
-        Optional<Brand> optional = Optional.ofNullable(brandAdminService.update(id, requestDto));
-        return optional.map(brand -> {
-            BrandResponse response = BrandResponse.of(brand);
-            return ResponseEntity.ok(response);
-        }).orElse(ResponseEntity.notFound().build());
+        Brand brand = brandAdminService.update(id, requestDto, imageFile);
+        BrandResponse response = BrandResponse.of(brand);
+        return ApiResponse.success(response);
     }
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Delete Brand", description = "브랜드 정보 삭제")
-    public ResponseEntity<Void> deleteBrand(@PathVariable Long id) {
+    public ApiResponse deleteBrand(@PathVariable Long id) {
         brandAdminService.delete(id);
-        return ResponseEntity.ok().build();
+        return ApiResponse.success();
     }
 
 }

--- a/src/main/java/com/thekey/stylekeyserver/brand/domain/Brand.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/domain/Brand.java
@@ -1,8 +1,17 @@
 package com.thekey.stylekeyserver.brand.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.thekey.stylekeyserver.image.domain.Image;
 import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,6 +24,7 @@ public class Brand {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "brand_id")
     private Long id;
 
     @Column(name = "brand_title")
@@ -23,14 +33,12 @@ public class Brand {
     @Column(name = "brand_title_eng")
     private String title_eng;
 
-    @Column(name = "brand_description")
-    private String description;
-
     @Column(name = "brand_site_url")
     private String site_url;
 
-    @Column(name = "brand_image")
-    private String image;
+    @OneToOne
+    @JoinColumn(name = "brand_image_id")
+    private Image image;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "style_point_id")
@@ -38,23 +46,26 @@ public class Brand {
     private StylePoint stylePoint;
 
     @Builder
-    public Brand(String title, String title_eng, String description, String site_url, String image,
+    public Brand(String title, String title_eng, String site_url, Image image,
                  StylePoint stylePoint) {
         this.title = title;
         this.title_eng = title_eng;
-        this.description = description;
         this.site_url = site_url;
         this.image = image;
         this.stylePoint = stylePoint;
     }
 
-    public void update(String title, String title_eng, String description, String site_url, String image,
-                       StylePoint stylePoint) {
+    public void update(String title, String title_eng, String site_url, StylePoint stylePoint) {
         this.title = title;
         this.title_eng = title_eng;
-        this.description = description;
         this.site_url = site_url;
-        this.image = image;
         this.stylePoint = stylePoint;
+    }
+
+    public void setImage(Image newImage) {
+        if(this.image != null) {
+            this.image.setUnused();
+        }
+        this.image = newImage;
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/brand/dto/request/BrandRequest.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/dto/request/BrandRequest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.thekey.stylekeyserver.brand.domain.Brand;
 import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
@@ -16,32 +15,23 @@ import lombok.NoArgsConstructor;
 @JsonNaming(SnakeCaseStrategy.class)
 public class BrandRequest {
 
-    @Schema(description = "브랜드 이름", example = "솔티페블")
+    @Schema(description = "브랜드 이름")
     private String title;
 
-    @Schema(description = "브랜드 영문 이름", example = "salty pebble")
+    @Schema(description = "브랜드 영문 이름")
     private String title_eng;
 
-    @Schema(description = "브랜드 설명", example = "솔티페블은 일정한 형식이나 틀을 갖추지 않은 조약돌의 본질을 바라보고 비정형화적인 이미지에 맞춰 시대를 유동하는 컨템포러리 브랜드이다.")
-    private String description;
-
-    @Schema(description = "브랜드 웹 사이트 URL", example = "https://www.saltypebble.com/")
+    @Schema(description = "브랜드 웹 사이트 URL")
     private String site_url;
 
-    @Schema(description = "브랜드 이미지 URL", example = "brand_image_url")
-    private String image;
-
-    @Schema(description = "스타일 포인트 ID", example = "1")
+    @Schema(description = "스타일 포인트 ID")
     private Long stylePointId;
 
     @Builder
-    public BrandRequest(String title, String title_eng, String description, String site_url, String image,
-                        Long stylePointId) {
+    public BrandRequest(String title, String title_eng, String site_url, Long stylePointId) {
         this.title = title;
         this.title_eng = title_eng;
-        this.description = description;
         this.site_url = site_url;
-        this.image = image;
         this.stylePointId = stylePointId;
     }
 
@@ -49,9 +39,7 @@ public class BrandRequest {
         return Brand.builder()
                 .title(this.title)
                 .title_eng(this.title_eng)
-                .description(this.description)
                 .site_url(this.site_url)
-                .image(this.image)
                 .stylePoint(stylePoint)
                 .build();
     }

--- a/src/main/java/com/thekey/stylekeyserver/brand/dto/response/BrandResponse.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/dto/response/BrandResponse.java
@@ -13,47 +13,44 @@ import lombok.NoArgsConstructor;
 @JsonNaming(SnakeCaseStrategy.class)
 public class BrandResponse {
 
-    @Schema(description = "브랜드 ID", example = "1")
+    @Schema(description = "브랜드 ID")
     private Long id;
 
-    @Schema(description = "브랜드 이름", example = "솔티페블")
+    @Schema(description = "브랜드 이름")
     private String title;
 
-    @Schema(description = "브랜드 영문 이름", example = "salty pebble")
+    @Schema(description = "브랜드 영문 이름")
     private String title_eng;
 
-    @Schema(description = "브랜드 설명", example = "솔티페블은 일정한 형식이나 틀을 갖추지 않은 조약돌의 본질을 바라보고 비정형화적인 이미지에 맞춰 시대를 유동하는 컨템포러리 브랜드이다.")
-    private String description;
-
-    @Schema(description = "브랜드 웹 사이트 URL", example = "https://www.saltypebble.com/")
+    @Schema(description = "브랜드 웹 사이트 URL")
     private String site_url;
 
-    @Schema(description = "브랜드 이미지 URL", example = "brand_image_url")
-    private String image;
+    @Schema(description = "브랜드 이미지 URL")
+    private String imageUrl;
 
-    @Schema(description = "스타일 포인트 ID", example = "1")
+    @Schema(description = "스타일 포인트 ID")
     private Long stylePointId;
 
     @Builder
-    public BrandResponse(Long id, String title, String title_eng, String description, String site_url, String image,
+    public BrandResponse(Long id, String title, String title_eng, String site_url, String imageUrl,
                          Long stylePointId) {
         this.id = id;
         this.title = title;
         this.title_eng = title_eng;
-        this.description = description;
         this.site_url = site_url;
-        this.image = image;
+        this.imageUrl = imageUrl;
         this.stylePointId = stylePointId;
     }
 
     public static BrandResponse of(Brand brand) {
+        String imageUrl = brand.getImage().getUrl();
+
         return BrandResponse.builder()
                 .id(brand.getId())
                 .title(brand.getTitle())
                 .title_eng(brand.getTitle_eng())
-                .description(brand.getDescription())
                 .site_url(brand.getSite_url())
-                .image(brand.getImage())
+                .imageUrl(imageUrl)
                 .stylePointId(brand.getStylePoint().getId())
                 .build();
     }

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminService.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminService.java
@@ -2,11 +2,13 @@ package com.thekey.stylekeyserver.brand.service;
 
 import com.thekey.stylekeyserver.brand.domain.Brand;
 import com.thekey.stylekeyserver.brand.dto.request.BrandRequest;
+import java.nio.file.FileAlreadyExistsException;
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface BrandAdminService {
 
-    Brand create(BrandRequest requestDto);
+    Brand create(BrandRequest requestDto, MultipartFile imageFile) throws Exception;
 
     Brand findById(Long id);
 
@@ -14,7 +16,7 @@ public interface BrandAdminService {
 
     List<Brand> findByStylePointId(Long id);
 
-    Brand update(Long id, BrandRequest requestDto);
+    Brand update(Long id, BrandRequest requestDto, MultipartFile imageFile) throws Exception;
 
     void delete(Long id);
 

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminService.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminService.java
@@ -2,7 +2,6 @@ package com.thekey.stylekeyserver.brand.service;
 
 import com.thekey.stylekeyserver.brand.domain.Brand;
 import com.thekey.stylekeyserver.brand.dto.request.BrandRequest;
-import java.nio.file.FileAlreadyExistsException;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
@@ -4,67 +4,99 @@ import com.thekey.stylekeyserver.brand.BrandErrorMessage;
 import com.thekey.stylekeyserver.brand.domain.Brand;
 import com.thekey.stylekeyserver.brand.dto.request.BrandRequest;
 import com.thekey.stylekeyserver.brand.repository.BrandRepository;
+import com.thekey.stylekeyserver.image.domain.Image;
+import com.thekey.stylekeyserver.image.domain.Type;
+import com.thekey.stylekeyserver.image.repository.ImageRepository;
+import com.thekey.stylekeyserver.s3.S3Service;
 import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
 import com.thekey.stylekeyserver.stylepoint.service.StylePointAdminService;
-
-import java.util.List;
-
 import jakarta.persistence.EntityNotFoundException;
-import jakarta.transaction.Transactional;
+import java.io.IOException;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class BrandAdminServiceImpl implements BrandAdminService {
 
     private final BrandRepository brandRepository;
+    private final ImageRepository imageRepository;
     private final StylePointAdminService stylePointAdminService;
+    private final S3Service s3Service;
 
     @Override
-    public Brand create(BrandRequest requestDto) {
+    @Transactional
+    public Brand create(BrandRequest requestDto, MultipartFile imageFile) throws IOException {
+        Image image = s3Service.uploadFile(imageFile, Type.BRAND);
+        imageRepository.save(image);
         StylePoint stylePoint = stylePointAdminService.findById(requestDto.getStylePointId());
-        return brandRepository.save(requestDto.toEntity(stylePoint));
+
+        Brand brand = requestDto.toEntity(stylePoint);
+        brand.setImage(image);
+        return brandRepository.save(brand);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Brand findById(Long id) {
         return brandRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(BrandErrorMessage.NOT_FOUND_BRAND.get() + id));
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<Brand> findAll() {
         return brandRepository.findAll();
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<Brand> findByStylePointId(Long id) {
         StylePoint stylePoint = stylePointAdminService.findById(id);
         return brandRepository.findBrandByStylePoint(stylePoint);
     }
 
     @Override
-    public Brand update(Long id, BrandRequest requestDto) {
+    @Transactional
+    public Brand update(Long id, BrandRequest requestDto, MultipartFile imageFile) throws IOException {
         Brand brand = brandRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(BrandErrorMessage.NOT_FOUND_BRAND.get() + id));
 
         StylePoint stylePoint = stylePointAdminService.findById(requestDto.getStylePointId());
 
+        Image oldImage = brand.getImage();
+        if (oldImage != null) {
+            oldImage.setUnused();
+            imageRepository.save(oldImage);
+
+            Image newImage = s3Service.uploadFile(imageFile, Type.BRAND);
+            imageRepository.save(newImage);
+            brand.setImage(newImage);
+            brandRepository.save(brand);
+        }
         brand.update(requestDto.getTitle(),
                 requestDto.getTitle_eng(),
-                requestDto.getDescription(),
                 requestDto.getSite_url(),
-                requestDto.getImage(),
-                requestDto.toEntity(stylePoint).getStylePoint());
+                stylePoint);
 
         return brand;
     }
 
     @Override
+    @Transactional
     public void delete(Long id) {
+        Brand brand = brandRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(BrandErrorMessage.NOT_FOUND_BRAND.get() + id));
+
+        Image image = brand.getImage();
+
+        if (image != null) {
+            image.setUnused();
+            imageRepository.save(image);
+        }
         brandRepository.deleteById(id);
     }
-
 }

--- a/src/main/java/com/thekey/stylekeyserver/common/ApiResponse.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/ApiResponse.java
@@ -1,9 +1,11 @@
 package com.thekey.stylekeyserver.common;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
 
     private int code;
@@ -11,7 +13,7 @@ public class ApiResponse<T> {
     private String message;
     private T data;
 
-    public ApiResponse(HttpStatus status, String message, T data) {
+    private ApiResponse(HttpStatus status, String message, T data) {
         this.code = status.value();
         this.status = status;
         this.message = message;
@@ -24,31 +26,34 @@ public class ApiResponse<T> {
         this.message = message;
     }
 
-    public static <T> ApiResponse<T> of(HttpStatus httpStatus, String message, T data) {
-        return new ApiResponse<>(httpStatus, message, data);
+    public static <T> ApiResponse<T> of(HttpStatus status, String message, T data) {
+        return new ApiResponse<>(status, message, data);
     }
 
-    public static <T> ApiResponse<T> of(HttpStatus httpStatus, T data) {
-        return of(httpStatus, httpStatus.getReasonPhrase(), data);
+    public static <T> ApiResponse<T> of(HttpStatus status, String message) {
+        return new ApiResponse<>(status, message);
     }
-
     public static <T> ApiResponse<T> success(T data) {
         return of(HttpStatus.OK, SuccessCode.SUCCESS.getMessage(), data);
     }
 
-    public static <T> ApiResponse<T> fail() {
-        return new ApiResponse<>(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+    public static <T> ApiResponse<T> success() {
+        return of(HttpStatus.OK, SuccessCode.SUCCESS.getMessage());
+    }
+
+    public static <T> ApiResponse<T> fail(HttpStatus status, String message) {
+        return of(status, message);
     }
 
     public static <T> ApiResponse<T> invalidAccessToken() {
-        return new ApiResponse<>(HttpStatus.UNAUTHORIZED, ErrorCode.INVALID_ACCESS_TOKEN.getMessage());
+        return of(HttpStatus.UNAUTHORIZED, ErrorCode.INVALID_ACCESS_TOKEN.getMessage());
     }
 
     public static <T> ApiResponse<T> invalidRefreshToken() {
-        return new ApiResponse<>(HttpStatus.UNAUTHORIZED, ErrorCode.INVALID_REFRESH_TOKEN.getMessage());
+        return of(HttpStatus.UNAUTHORIZED, ErrorCode.INVALID_REFRESH_TOKEN.getMessage());
     }
 
     public static <T> ApiResponse<T> notExpiredTokenYet() {
-        return new ApiResponse<>(HttpStatus.BAD_REQUEST, ErrorCode.NOT_EXPIRED_TOKEN_YET.getMessage());
+        return of(HttpStatus.BAD_REQUEST, ErrorCode.NOT_EXPIRED_TOKEN_YET.getMessage());
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.thekey.stylekeyserver.common;
 
 import com.amazonaws.AmazonServiceException;
+import com.thekey.stylekeyserver.s3.S3ErrorMessage;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
@@ -14,7 +15,12 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(IOException.class)
     public ApiResponse handleIOException(IOException e) {
-        return ApiResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+        return ApiResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INVALID_IMAGE_FORMAT.getMessage());
+    }
+
+    @ExceptionHandler(FileAlreadyExistsException.class)
+    public ApiResponse handleFileAlreadyExistsException(FileAlreadyExistsException e) {
+        return ApiResponse.of(HttpStatus.BAD_REQUEST, S3ErrorMessage.FILE_ALREADY_EXISTS.getMessage());
     }
 
     @ExceptionHandler(AmazonServiceException.class)
@@ -22,7 +28,7 @@ public class GlobalExceptionHandler {
         return ApiResponse.of(HttpStatus.SERVICE_UNAVAILABLE, ErrorCode.FILE_UPLOAD_FAILED.getMessage());
     }
 
-    @ExceptionHandler({UnsupportedEncodingException.class, MalformedURLException.class, FileAlreadyExistsException.class})
+    @ExceptionHandler({UnsupportedEncodingException.class, MalformedURLException.class})
     public ApiResponse handleS3Exception(Exception e) {
         return ApiResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
     }

--- a/src/main/java/com/thekey/stylekeyserver/image/domain/Image.java
+++ b/src/main/java/com/thekey/stylekeyserver/image/domain/Image.java
@@ -1,0 +1,59 @@
+package com.thekey.stylekeyserver.image.domain;
+
+import com.thekey.stylekeyserver.brand.domain.Brand;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Image {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    private Long id;
+
+    @Column(name = "image_url", nullable = false)
+    private String url;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "image_type", nullable = false)
+    private Type type;
+
+    @Column(name = "image_file_name")
+    private String fileName;
+
+    @Column(name = "image_is_used")
+    private Boolean isUsed;
+
+    @Column(name = "delete_at")
+    private LocalDateTime deleteAt;
+
+    @OneToOne(mappedBy = "image")
+    private Brand brand;
+
+    @Builder
+    public Image(String url, Type type, String fileName, Boolean isUsed) {
+        this.url = url;
+        this.type = type;
+        this.fileName = fileName;
+        this.isUsed = isUsed;
+    }
+
+    public void setUnused() {
+        this.isUsed = false;
+        this.deleteAt = LocalDateTime.now().plusDays(1);
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/image/domain/Type.java
+++ b/src/main/java/com/thekey/stylekeyserver/image/domain/Type.java
@@ -1,0 +1,17 @@
+package com.thekey.stylekeyserver.image.domain;
+
+public enum Type {
+    BRAND("brand"),
+    COORDINATE_LOOK("coordinateLook"),
+    ITEM("item");
+
+    private String name;
+
+    Type(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/image/repository/ImageRepository.java
+++ b/src/main/java/com/thekey/stylekeyserver/image/repository/ImageRepository.java
@@ -1,0 +1,9 @@
+package com.thekey.stylekeyserver.image.repository;
+
+import com.thekey.stylekeyserver.image.domain.Image;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+    List<Image> findByIsUsed(boolean b);
+}

--- a/src/main/java/com/thekey/stylekeyserver/image/service/ImageBatchService.java
+++ b/src/main/java/com/thekey/stylekeyserver/image/service/ImageBatchService.java
@@ -1,0 +1,32 @@
+package com.thekey.stylekeyserver.image.service;
+
+import com.thekey.stylekeyserver.image.domain.Image;
+import com.thekey.stylekeyserver.image.repository.ImageRepository;
+import com.thekey.stylekeyserver.s3.S3Service;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ImageBatchService {
+    private final ImageRepository imageRepository;
+    private final S3Service s3Service;
+
+    @Scheduled(cron = "0 0 0 * * *")  // 매일 새벽 0시에 실행
+    public void deleteUnusedImages() throws MalformedURLException, UnsupportedEncodingException {
+        List<Image> unusedImages = imageRepository.findByIsUsed(false);
+
+        for (Image image : unusedImages) {
+            // 이미지가 24시간 이상 사용되지 않았다면 S3에서 이미지 파일 삭제
+            if (image.getDeleteAt().isBefore(LocalDateTime.now())) {
+                s3Service.deleteFile(image.getUrl(), image.getType());
+                imageRepository.delete(image);
+            }
+        }
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/s3/S3Config.java
+++ b/src/main/java/com/thekey/stylekeyserver/s3/S3Config.java
@@ -1,0 +1,34 @@
+package com.thekey.stylekeyserver.s3;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 s3client() {
+        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .withRegion(region)
+                .build();
+    }
+
+}

--- a/src/main/java/com/thekey/stylekeyserver/s3/S3ErrorMessage.java
+++ b/src/main/java/com/thekey/stylekeyserver/s3/S3ErrorMessage.java
@@ -1,0 +1,16 @@
+package com.thekey.stylekeyserver.s3;
+
+import lombok.Getter;
+
+@Getter
+public enum S3ErrorMessage {
+    FILE_UPLOAD_FAILED("이미지 파일 업로드에 실패했습니다."),
+    FILE_ALREADY_EXISTS("동일한 이름의 이미지 파일이 존재합니다."),
+    FAIL_IMAGE_DELETE("이미지 삭제에 실패했습니다.");
+
+    private String message;
+
+    S3ErrorMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/s3/S3Service.java
+++ b/src/main/java/com/thekey/stylekeyserver/s3/S3Service.java
@@ -40,7 +40,6 @@ public class S3Service {
     public Image uploadFile(MultipartFile file, Type imageType) throws IOException {
         String fileName = generateFileName(file, imageType);
 
-        // 동일한 이름의 파일이 이미 존재하는지 확인한다.
         if (s3Client.doesObjectExist(bucket, fileName)) {
             throw new FileAlreadyExistsException(S3ErrorMessage.FILE_ALREADY_EXISTS.getMessage());
         }

--- a/src/main/java/com/thekey/stylekeyserver/s3/S3Service.java
+++ b/src/main/java/com/thekey/stylekeyserver/s3/S3Service.java
@@ -1,0 +1,117 @@
+package com.thekey.stylekeyserver.s3;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.thekey.stylekeyserver.image.domain.Image;
+import com.thekey.stylekeyserver.image.domain.Type;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+    private final AmazonS3 s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.s3.brand}")
+    private String brandFolder;
+
+    @Value("${cloud.aws.s3.coordinateLook}")
+    private String coordinateLookFolder;
+
+    @Value("${cloud.aws.s3.item}")
+    private String itemFolder;
+
+    public Image uploadFile(MultipartFile file, Type imageType) throws IOException {
+        String fileName = generateFileName(file, imageType);
+
+        // 동일한 이름의 파일이 이미 존재하는지 확인한다.
+        if (s3Client.doesObjectExist(bucket, fileName)) {
+            throw new FileAlreadyExistsException(S3ErrorMessage.FILE_ALREADY_EXISTS.getMessage());
+        }
+
+        File convertedFile = convertMultiPartToFile(file);
+        uploadFileTos3bucket(fileName, convertedFile);
+        String url = getFileUrl(fileName);
+
+        return Image.builder()
+                .url(url)
+                .type(imageType)
+                .fileName(fileName)
+                .isUsed(true)
+                .build();
+    }
+
+    public void deleteFile(String fileUrl, Type imageType)
+            throws AmazonServiceException, UnsupportedEncodingException, MalformedURLException {
+        String folderName = getFolderName(imageType);
+        URL url = new URL(fileUrl);
+        String fileName = url.getPath();
+        String fullFileName = folderName + fileName.substring(fileName.indexOf("/"));
+        String decodedFullFileName = URLDecoder.decode(fullFileName, StandardCharsets.UTF_8.toString());
+        s3Client.deleteObject(new DeleteObjectRequest(bucket, decodedFullFileName));
+    }
+
+    private String getFolderName(Type imageType) {
+        switch (imageType) {
+            case BRAND:
+                return brandFolder;
+            case COORDINATE_LOOK:
+                return coordinateLookFolder;
+            case ITEM:
+                return itemFolder;
+            default:
+                return "";
+        }
+    }
+
+    private File convertMultiPartToFile(MultipartFile file) throws IOException {
+        File convertedFile = new File(file.getOriginalFilename());
+
+        // FileOutputStream을 닫아야 파일이 닫힘
+        // 만약 파일이 계속 열러있으면 삭제가 안 될 수 있음
+        try (FileOutputStream fos = new FileOutputStream(convertedFile)) {
+            fos.write(file.getBytes());
+        }
+        return convertedFile;
+    }
+
+    private String generateFileName(MultipartFile multiPart, Type imageType) {
+        return new StringBuilder()
+                .append(imageType.getName())
+                .append("/")
+                .append(multiPart.getOriginalFilename())
+                .toString();
+    }
+
+    private void uploadFileTos3bucket(String fileName, File file) throws FileAlreadyExistsException {
+        if (s3Client.doesObjectExist(bucket, fileName)) {
+            throw new FileAlreadyExistsException(S3ErrorMessage.FILE_ALREADY_EXISTS.getMessage() + fileName);
+        }
+
+        s3Client.putObject(new PutObjectRequest(bucket, fileName, file));
+        // s3에 객체 생성 시 임시 파일이 자동으로 남는다.
+        if (!file.delete()) {
+            throw new RuntimeException(S3ErrorMessage.FILE_UPLOAD_FAILED.getMessage());
+        }
+    }
+
+    private String getFileUrl(String fileName) {
+        return s3Client.getUrl(bucket, fileName).toString();
+    }
+}

--- a/src/main/resources/data/style-point.sql
+++ b/src/main/resources/data/style-point.sql
@@ -1,31 +1,31 @@
 insert into style_point (style_point_title, style_point_description, style_point_image)
 values ('Unique', '변화하는 트렌드를 반영하여 평범하지 않고 개성있는 디테일을 추구하는 스타일',
-        'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/%E1%84%8B%E1%85%B2%E1%84%82%E1%85%B5%E1%84%8F%E1%85%B3%E1%84%91%E1%85%A9%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%90%E1%85%B3.png');
+        'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/unique_point.png');
 
 insert into style_point (style_point_title, style_point_description, style_point_image)
 values ('Street', '격식을 갖추지 않고 길거리에서 편하게 입을 수 있는 힙한 스타일',
-        'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/%E1%84%89%E1%85%B3%E1%84%90%E1%85%B3%E1%84%85%E1%85%B5%E1%86%BA%E1%84%91%E1%85%A9%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%90%E1%85%B3.png');
+        'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/street_point.png');
 
 insert into style_point (style_point_title, style_point_description, style_point_image)
 values ('Modern', '장식적인 것 없이 깔끔하고 심플하며 직선적인 실루엣을 추구하는 스타일',
-        'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/%E1%84%86%E1%85%A9%E1%84%83%E1%85%A5%E1%86%AB%E1%84%91%E1%85%A9%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%90%E1%85%B3.png');
+        'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/modern_point.png');
 
 insert into style_point (style_point_title, style_point_description, style_point_image)
 values ('Normal', '일상적이고 평범한 착장이 무난하지 않도록 센스있는 포인트가 들어간 스타일',
-        'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/%E1%84%82%E1%85%A9%E1%84%86%E1%85%A5%E1%86%AF%E1%84%91%E1%85%A9%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%90%E1%85%B3.png');
+        'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/nomal_point.png');
 
 insert into style_point (style_point_title, style_point_description, style_point_image)
 values ('Lovely', '사랑스러운 소녀같이 귀엽고 로맨틱하면서 여성스러운 무드를 강조한 스타일',
-        'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/%E1%84%85%E1%85%A5%E1%84%87%E1%85%B3%E1%86%AF%E1%84%85%E1%85%B5%E1%84%91%E1%85%A9%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%90%E1%85%B3.jpg');
+        'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/lovely_point.jpg');
 
 insert into style_point (style_point_title, style_point_description, style_point_image)
 values ('Retro', '1990-2000년대의 감성을 재해석하여 오래된 듯한 멋진 느낌이 드는 스타일',
-        'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/%E1%84%85%E1%85%A6%E1%84%90%E1%85%B3%E1%84%85%E1%85%A9%E1%84%91%E1%85%A9%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%90%E1%85%B3.jpg');
+        'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/retro_point.jpg');
 
 insert into style_point (style_point_title, style_point_description, style_point_image)
 values ('Glam', '섹시함이 강조되는 화려하고 여성스러운 스타일',
-        'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/%E1%84%80%E1%85%B3%E1%86%AF%E1%84%85%E1%85%A2%E1%86%B7%E1%84%91%E1%85%A9%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%90%E1%85%B3.png');
+        'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/glam_point.png');
 
 insert into style_point (style_point_title, style_point_description, style_point_image)
 values ('Active', '스포츠웨어와 일상복의 경계를 허물고 활동적인 이미지를 표현하는 스타일',
-        'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/%E1%84%8B%E1%85%A6%E1%86%A8%E1%84%90%E1%85%B5%E1%84%87%E1%85%B3%E1%84%91%E1%85%A9%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%90%E1%85%B3.png');
+        'https://stylekeybucket.s3.ap-northeast-2.amazonaws.com/stylepoint/active_point.png');


### PR DESCRIPTION
### 작업 내용
- 브랜드 정보를 등록할 때, 이미지 파일을 첨부하여 요청을 보내면 해당 파일이 Amazon S3에 업로드되며, 그 객체의 URL이 데이터베이스에 저장됩니다.
- 이전에는 브랜드, 코디룩, 아이템 엔티티 각각이 이미지 URL을 String 형태로 가지고 있었지만, 이미지를 별도로 관리하는 것이 더 효율적이라 판단하여 `Image` 엔티티를 별도로 생성하고, 필요한 객체에 매핑하였습니다.
- 브랜드 정보를 수정하거나 삭제할 때, 해당 이미지는 `isUsed` 속성이 `false`로 설정됩니다. Image 테이블에서  `isUsed=false` 인 데이터는 24시간 후에 Amazon S3에서 해당 이미지를 삭제되도록 스케줄링하였습니다.
- Controller의 반환 값을 `ResponseEntity`에서 자체적으로 정의한 `ApiResponse`로 모두 변경하였고, **생성과 삭제 api는 별도의 반환 데이터를 없애고 상태 코드만 반환하도록 변경했습니다.**
- 스타일포인트 이미지 객체 URL이 불필요하게 길어지는 문제가 있어 파일명을 영문으로 바꿨더니 URL 길이가 단축되어 이 수정사항 업로드 합니다.

---


Test Code를 작성하여 실제 24시간이 지나면 S3에서 삭제되는지 기능을 테스트 해볼 예정입니다.
