### PR TITLE
코디룩 좋아요 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 	implementation group: 'io.swagger.core.v3', name: 'swagger-core-jakarta', version: '2.2.7'
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	/* Redis cache */
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	
 	compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'

--- a/src/main/java/com/thekey/stylekeyserver/StyleKeyServerApplication.java
+++ b/src/main/java/com/thekey/stylekeyserver/StyleKeyServerApplication.java
@@ -7,8 +7,10 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import com.thekey.stylekeyserver.config.properties.AppProperties;
 import com.thekey.stylekeyserver.config.properties.CorsProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 @EnableConfigurationProperties({
         CorsProperties.class,

--- a/src/main/java/com/thekey/stylekeyserver/StyleKeyServerApplication.java
+++ b/src/main/java/com/thekey/stylekeyserver/StyleKeyServerApplication.java
@@ -2,24 +2,11 @@ package com.thekey.stylekeyserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-import com.thekey.stylekeyserver.config.properties.AppProperties;
-import com.thekey.stylekeyserver.config.properties.CorsProperties;
-import org.springframework.scheduling.annotation.EnableScheduling;
-
-@EnableJpaAuditing
-@EnableScheduling
 @SpringBootApplication
-@EnableConfigurationProperties({
-        CorsProperties.class,
-        AppProperties.class
-})
 public class StyleKeyServerApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(StyleKeyServerApplication.class, args);
-	}
-
+    public static void main(String[] args) {
+        SpringApplication.run(StyleKeyServerApplication.class, args);
+    }
 }

--- a/src/main/java/com/thekey/stylekeyserver/auth/controller/UserController.java
+++ b/src/main/java/com/thekey/stylekeyserver/auth/controller/UserController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.thekey.stylekeyserver.auth.entity.User;
 import com.thekey.stylekeyserver.auth.service.UserService;
-import com.thekey.stylekeyserver.common.ApiResponse;
+import com.thekey.stylekeyserver.common.exception.ApiResponse;
 
 
 @RestController

--- a/src/main/java/com/thekey/stylekeyserver/base/BaseTimeConfig.java
+++ b/src/main/java/com/thekey/stylekeyserver/base/BaseTimeConfig.java
@@ -1,0 +1,9 @@
+package com.thekey.stylekeyserver.base;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class BaseTimeConfig {
+}

--- a/src/main/java/com/thekey/stylekeyserver/brand/controller/BrandAdminController.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/controller/BrandAdminController.java
@@ -34,10 +34,10 @@ public class BrandAdminController {
     @PostMapping
     @Operation(summary = "Create Brand", description = "브랜드 정보 등록")
     public ApiResponse createBrand(@RequestPart BrandRequest requestDto,
-                                   @RequestPart("imageFile") MultipartFile imageFile) throws Exception {
+                                   @RequestPart("brand_imageFile") MultipartFile imageFile) throws Exception {
 
-        if (imageFile == null || imageFile.isEmpty()) {
-            return ApiResponse.fail(HttpStatus.BAD_REQUEST, ErrorCode.INVALID_IMAGE_FORMAT.getMessage());
+        if (imageFile.isEmpty()) {
+            return ApiResponse.fail(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getMessage());
         }
         brandAdminService.create(requestDto, imageFile);
         return ApiResponse.success();
@@ -56,7 +56,7 @@ public class BrandAdminController {
 
     @GetMapping
     @Operation(summary = "Read All Brands", description = "브랜드 정보 전체 조회")
-    public ApiResponse getBrands() {
+    public ApiResponse<List<BrandResponse>> getBrands() {
         List<Brand> brands = brandAdminService.findAll();
         List<BrandResponse> response = brands.stream()
                 .map(BrandResponse::of)
@@ -93,7 +93,7 @@ public class BrandAdminController {
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Delete Brand", description = "브랜드 정보 삭제")
-    public ApiResponse deleteBrand(@PathVariable Long id) {
+    public ApiResponse<Void> deleteBrand(@PathVariable Long id) {
         brandAdminService.delete(id);
         return ApiResponse.success();
     }

--- a/src/main/java/com/thekey/stylekeyserver/brand/controller/BrandAdminController.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/controller/BrandAdminController.java
@@ -4,10 +4,12 @@ import com.thekey.stylekeyserver.brand.domain.Brand;
 import com.thekey.stylekeyserver.brand.dto.request.BrandRequest;
 import com.thekey.stylekeyserver.brand.dto.response.BrandResponse;
 import com.thekey.stylekeyserver.brand.service.BrandAdminService;
-import com.thekey.stylekeyserver.common.ApiResponse;
-import com.thekey.stylekeyserver.common.ErrorCode;
+import com.thekey.stylekeyserver.common.exception.ApiResponse;
+import com.thekey.stylekeyserver.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -93,7 +95,8 @@ public class BrandAdminController {
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Delete Brand", description = "브랜드 정보 삭제")
-    public ApiResponse<Void> deleteBrand(@PathVariable Long id) {
+    public ApiResponse<Void> deleteBrand(@PathVariable Long id)
+            throws MalformedURLException, UnsupportedEncodingException {
         brandAdminService.delete(id);
         return ApiResponse.success();
     }

--- a/src/main/java/com/thekey/stylekeyserver/brand/domain/Brand.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/domain/Brand.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,6 +21,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "brand")
 public class Brand {
 
     @Id

--- a/src/main/java/com/thekey/stylekeyserver/brand/dto/response/BrandResponse.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/dto/response/BrandResponse.java
@@ -26,19 +26,19 @@ public class BrandResponse {
     private String site_url;
 
     @Schema(description = "브랜드 이미지 URL")
-    private String imageUrl;
+    private String brandImageUrl;
 
     @Schema(description = "스타일 포인트 ID")
     private Long stylePointId;
 
     @Builder
-    public BrandResponse(Long id, String title, String title_eng, String site_url, String imageUrl,
+    public BrandResponse(Long id, String title, String title_eng, String site_url, String brandImageUrl,
                          Long stylePointId) {
         this.id = id;
         this.title = title;
         this.title_eng = title_eng;
         this.site_url = site_url;
-        this.imageUrl = imageUrl;
+        this.brandImageUrl = brandImageUrl;
         this.stylePointId = stylePointId;
     }
 
@@ -50,7 +50,7 @@ public class BrandResponse {
                 .title(brand.getTitle())
                 .title_eng(brand.getTitle_eng())
                 .site_url(brand.getSite_url())
-                .imageUrl(imageUrl)
+                .brandImageUrl(imageUrl)
                 .stylePointId(brand.getStylePoint().getId())
                 .build();
     }

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminService.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminService.java
@@ -2,6 +2,8 @@ package com.thekey.stylekeyserver.brand.service;
 
 import com.thekey.stylekeyserver.brand.domain.Brand;
 import com.thekey.stylekeyserver.brand.dto.request.BrandRequest;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -17,6 +19,6 @@ public interface BrandAdminService {
 
     Brand update(Long id, BrandRequest requestDto, MultipartFile imageFile) throws Exception;
 
-    void delete(Long id);
+    void delete(Long id) throws MalformedURLException, UnsupportedEncodingException;
 
 }

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
@@ -67,16 +67,19 @@ public class BrandAdminServiceImpl implements BrandAdminService {
 
         StylePoint stylePoint = stylePointAdminService.findById(requestDto.getStylePointId());
 
-        Image oldImage = brand.getImage();
-        if (oldImage != null) {
-            oldImage.setUnused();
-            imageRepository.save(oldImage);
+        if(!imageFile.isEmpty()) {
+            Image oldImage = brand.getImage();
+            if (oldImage != null) {
+                oldImage.setUnused();
+                imageRepository.save(oldImage);
 
-            Image newImage = s3Service.uploadFile(imageFile, Type.BRAND);
-            imageRepository.save(newImage);
-            brand.setImage(newImage);
-            brandRepository.save(brand);
+                Image newImage = s3Service.uploadFile(imageFile, Type.BRAND);
+                imageRepository.save(newImage);
+                brand.setImage(newImage);
+                brandRepository.save(brand);
+            }
         }
+
         brand.update(requestDto.getTitle(),
                 requestDto.getTitle_eng(),
                 requestDto.getSite_url(),

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
@@ -7,7 +7,7 @@ import com.thekey.stylekeyserver.brand.repository.BrandRepository;
 import com.thekey.stylekeyserver.image.domain.Image;
 import com.thekey.stylekeyserver.image.domain.Type;
 import com.thekey.stylekeyserver.image.repository.ImageRepository;
-import com.thekey.stylekeyserver.common.s3.S3Service;
+import com.thekey.stylekeyserver.common.s3.service.S3Service;
 import com.thekey.stylekeyserver.image.service.ImageService;
 import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
 import com.thekey.stylekeyserver.stylepoint.service.StylePointAdminService;

--- a/src/main/java/com/thekey/stylekeyserver/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/GlobalExceptionHandler.java
@@ -35,7 +35,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(RuntimeException.class)
     public ApiResponse handleRuntimeException(RuntimeException e) {
-        return ApiResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+        return ApiResponse.of(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getMessage());
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/thekey/stylekeyserver/common/exception/ApiResponse.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/exception/ApiResponse.java
@@ -1,4 +1,4 @@
-package com.thekey.stylekeyserver.common;
+package com.thekey.stylekeyserver.common.exception;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;

--- a/src/main/java/com/thekey/stylekeyserver/common/exception/ErrorCode.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/exception/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.thekey.stylekeyserver.common;
+package com.thekey.stylekeyserver.common.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/thekey/stylekeyserver/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,7 @@
-package com.thekey.stylekeyserver.common;
+package com.thekey.stylekeyserver.common.exception;
 
 import com.amazonaws.AmazonServiceException;
-import com.thekey.stylekeyserver.s3.S3ErrorMessage;
+import com.thekey.stylekeyserver.common.s3.S3ErrorMessage;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;

--- a/src/main/java/com/thekey/stylekeyserver/common/exception/SuccessCode.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/exception/SuccessCode.java
@@ -1,4 +1,4 @@
-package com.thekey.stylekeyserver.common;
+package com.thekey.stylekeyserver.common.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/thekey/stylekeyserver/common/properties/AppProperties.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/properties/AppProperties.java
@@ -1,4 +1,4 @@
-package com.thekey.stylekeyserver.config.properties;
+package com.thekey.stylekeyserver.common.properties;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/thekey/stylekeyserver/common/properties/CorsProperties.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/properties/CorsProperties.java
@@ -1,4 +1,4 @@
-package com.thekey.stylekeyserver.config.properties;
+package com.thekey.stylekeyserver.common.properties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/src/main/java/com/thekey/stylekeyserver/common/properties/PropertiesConfig.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/properties/PropertiesConfig.java
@@ -1,0 +1,12 @@
+package com.thekey.stylekeyserver.common.properties;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties({
+        CorsProperties.class,
+        AppProperties.class
+})
+public class PropertiesConfig {
+}

--- a/src/main/java/com/thekey/stylekeyserver/common/redis/RedisConfig.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/redis/RedisConfig.java
@@ -1,0 +1,36 @@
+package com.thekey.stylekeyserver.common.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/common/redis/RedisService.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/redis/RedisService.java
@@ -1,0 +1,59 @@
+package com.thekey.stylekeyserver.common.redis;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class RedisService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public <T> void setData(String key, T value) throws JsonProcessingException {
+        if (value == null) {
+            throw new IllegalArgumentException("value must not be null");
+        }
+        String serializedValue = objectMapper.writeValueAsString(value);
+        redisTemplate.opsForValue().set(key, serializedValue);
+    }
+
+    public <T> T getData(String key, TypeReference<T> type) throws JsonProcessingException {
+        String serializedValue = (String) redisTemplate.opsForValue().get(key);
+        if (serializedValue == null) {
+            return null;
+        }
+        T result = objectMapper.readValue(serializedValue, type);
+        return objectMapper.readValue(serializedValue, type);
+    }
+
+
+    public <T> void deleteData(String key, TypeReference<T> type) throws JsonProcessingException {
+        T data = getData(key, type);
+        if(data != null) {
+            redisTemplate.delete(key);
+        }
+    }
+
+
+    public void increaseLikeCount(String id) {
+        redisTemplate.opsForValue().increment("likeCount:" + id);
+    }
+
+    public void decreaseLikeCount(String id) {
+        Object likeCount = redisTemplate.opsForValue().get("likeCount:" + id);
+        if (likeCount != null && ((Number) likeCount).longValue() > 0) {
+            redisTemplate.opsForValue().decrement("likeCount:" + id);
+        }
+    }
+
+    public Object getLikeCount(String id) {
+        return redisTemplate.opsForValue().get("likeCount:" + id);
+    }
+
+}
+

--- a/src/main/java/com/thekey/stylekeyserver/common/s3/S3Config.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/s3/S3Config.java
@@ -1,4 +1,4 @@
-package com.thekey.stylekeyserver.s3;
+package com.thekey.stylekeyserver.common.s3;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;

--- a/src/main/java/com/thekey/stylekeyserver/common/s3/S3ErrorMessage.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/s3/S3ErrorMessage.java
@@ -1,4 +1,4 @@
-package com.thekey.stylekeyserver.s3;
+package com.thekey.stylekeyserver.common.s3;
 
 import lombok.Getter;
 

--- a/src/main/java/com/thekey/stylekeyserver/common/s3/S3Service.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/s3/S3Service.java
@@ -58,10 +58,9 @@ public class S3Service {
 
     public void deleteFile(String fileUrl, Type imageType)
             throws AmazonServiceException, UnsupportedEncodingException, MalformedURLException {
-        String folderName = getFolderName(imageType);
         URL url = new URL(fileUrl);
         String fileName = url.getPath();
-        String fullFileName = folderName + fileName.substring(fileName.indexOf("/"));
+        String fullFileName = fileName.substring(1);
         String decodedFullFileName = URLDecoder.decode(fullFileName, StandardCharsets.UTF_8.toString());
         s3Client.deleteObject(new DeleteObjectRequest(bucket, decodedFullFileName));
     }

--- a/src/main/java/com/thekey/stylekeyserver/common/s3/S3Service.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/s3/S3Service.java
@@ -1,4 +1,4 @@
-package com.thekey.stylekeyserver.s3;
+package com.thekey.stylekeyserver.common.s3;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;

--- a/src/main/java/com/thekey/stylekeyserver/common/s3/config/S3Config.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/s3/config/S3Config.java
@@ -1,4 +1,4 @@
-package com.thekey.stylekeyserver.common.s3;
+package com.thekey.stylekeyserver.common.s3.config;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;

--- a/src/main/java/com/thekey/stylekeyserver/common/s3/config/SchedulingConfig.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/s3/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.thekey.stylekeyserver.common.s3.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/com/thekey/stylekeyserver/common/s3/service/S3Service.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/s3/service/S3Service.java
@@ -1,9 +1,10 @@
-package com.thekey.stylekeyserver.common.s3;
+package com.thekey.stylekeyserver.common.s3.service;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.thekey.stylekeyserver.common.s3.S3ErrorMessage;
 import com.thekey.stylekeyserver.image.domain.Image;
 import com.thekey.stylekeyserver.image.domain.Type;
 import java.io.File;

--- a/src/main/java/com/thekey/stylekeyserver/common/security/JwtConfig.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/security/JwtConfig.java
@@ -1,4 +1,4 @@
-package com.thekey.stylekeyserver.config.security;
+package com.thekey.stylekeyserver.common.security;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/thekey/stylekeyserver/common/security/SecurityConfig.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/security/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.thekey.stylekeyserver.config.security;
+package com.thekey.stylekeyserver.common.security;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,13 +14,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import com.thekey.stylekeyserver.auth.repository.UserRefreshTokenRepository;
-import com.thekey.stylekeyserver.config.properties.AppProperties;
-import com.thekey.stylekeyserver.config.properties.CorsProperties;
-import com.thekey.stylekeyserver.oauth.entity.RoleType;
+import com.thekey.stylekeyserver.common.properties.AppProperties;
+import com.thekey.stylekeyserver.common.properties.CorsProperties;
 import com.thekey.stylekeyserver.oauth.exception.RestAuthenticationEntryPoint;
 import com.thekey.stylekeyserver.oauth.filter.TokenAuthenticationFilter;
 import com.thekey.stylekeyserver.oauth.handler.OAuth2AuthenticationFailureHandler;
@@ -33,8 +31,6 @@ import com.thekey.stylekeyserver.oauth.token.AuthTokenProvider;
 
 import java.util.Arrays;
 import java.util.Collections;
-
-import static org.springframework.web.servlet.function.RequestPredicates.headers;
 
 
 @Configuration
@@ -141,20 +137,21 @@ public class SecurityConfig {
                 .requestMatchers("/swagger-ui/**").permitAll()
                 .requestMatchers("/v3/api-docs/**").permitAll()
                 .requestMatchers("/api/*").permitAll()
+                .requestMatchers("/admin/*").permitAll()
                 .anyRequest().authenticated()
                 .and()
 
                 .oauth2Login()
-                    .authorizationEndpoint().baseUri("/oauth2/authorization")
-                    .authorizationRequestRepository(oAuth2AuthorizationRequestBasedOnCookieRepository())
+                .authorizationEndpoint().baseUri("/oauth2/authorization")
+                .authorizationRequestRepository(oAuth2AuthorizationRequestBasedOnCookieRepository())
                 .and()
-                    .redirectionEndpoint()
-                    .baseUri("/login/oauth2/code/*") // /login/oauth2/code/**, /*/oauth2/code/* // /oauth/callback/kakao ///oauth/redirect
+                .redirectionEndpoint()
+                .baseUri("/login/oauth2/code/*") // /login/oauth2/code/**, /*/oauth2/code/* // /oauth/callback/kakao ///oauth/redirect
                 .and()
-                    .userInfoEndpoint().userService(oAuth2UserService)
+                .userInfoEndpoint().userService(oAuth2UserService)
                 .and()
-                    .successHandler(oAuth2AuthenticationSuccessHandler())
-                    .failureHandler(oAuth2AuthenticationFailureHandler())
+                .successHandler(oAuth2AuthenticationSuccessHandler())
+                .failureHandler(oAuth2AuthenticationFailureHandler())
 
 
 

--- a/src/main/java/com/thekey/stylekeyserver/coordinatelook/controller/CoordinateLookAdminController.java
+++ b/src/main/java/com/thekey/stylekeyserver/coordinatelook/controller/CoordinateLookAdminController.java
@@ -1,7 +1,7 @@
 package com.thekey.stylekeyserver.coordinatelook.controller;
 
-import com.thekey.stylekeyserver.common.ApiResponse;
-import com.thekey.stylekeyserver.common.ErrorCode;
+import com.thekey.stylekeyserver.common.exception.ApiResponse;
+import com.thekey.stylekeyserver.common.exception.ErrorCode;
 import com.thekey.stylekeyserver.coordinatelook.domain.CoordinateLook;
 import com.thekey.stylekeyserver.coordinatelook.dto.response.CoordinateLookDetailsResponse;
 import com.thekey.stylekeyserver.coordinatelook.dto.response.CoordinateLookResponse;
@@ -11,6 +11,8 @@ import com.thekey.stylekeyserver.item.dto.request.ItemRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -122,7 +124,7 @@ public class CoordinateLookAdminController {
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Delete CoordinateLook ", description = "코디룩 정보 삭제")
-    public ApiResponse<Void> delete(@PathVariable Long id) {
+    public ApiResponse<Void> delete(@PathVariable Long id) throws MalformedURLException, UnsupportedEncodingException {
         coordinateLookAdminService.delete(id);
         return ApiResponse.success();
     }

--- a/src/main/java/com/thekey/stylekeyserver/coordinatelook/controller/CoordinateLookAdminController.java
+++ b/src/main/java/com/thekey/stylekeyserver/coordinatelook/controller/CoordinateLookAdminController.java
@@ -1,26 +1,30 @@
 package com.thekey.stylekeyserver.coordinatelook.controller;
 
+import com.thekey.stylekeyserver.common.ApiResponse;
+import com.thekey.stylekeyserver.common.ErrorCode;
 import com.thekey.stylekeyserver.coordinatelook.domain.CoordinateLook;
 import com.thekey.stylekeyserver.coordinatelook.dto.response.CoordinateLookDetailsResponse;
 import com.thekey.stylekeyserver.coordinatelook.dto.response.CoordinateLookResponse;
 import com.thekey.stylekeyserver.coordinatelook.dto.request.CoordinateLookRequest;
 import com.thekey.stylekeyserver.coordinatelook.service.CoordinateLookAdminService;
+import com.thekey.stylekeyserver.item.dto.request.ItemRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "CoordinateLook", description = "CoordinateLook API")
 @RestController
@@ -32,78 +36,94 @@ public class CoordinateLookAdminController {
 
     @PostMapping
     @Operation(summary = "Create CoordinateLook", description = "코디룩 정보 등록")
-    public ResponseEntity<CoordinateLookResponse> create(@RequestBody CoordinateLookRequest requestDto) {
-        CoordinateLook coordinateLook = coordinateLookAdminService.create(requestDto);
-        return ResponseEntity.ok(CoordinateLookResponse.of(coordinateLook));
+    public ApiResponse create(@RequestPart CoordinateLookRequest requestDto,
+                              @RequestPart("coordinate-looks_imageFile") MultipartFile coordinateLookImageFile,
+                              @RequestPart("item_imageFile") List<MultipartFile> itemImageFiles) throws Exception {
+
+        if (coordinateLookImageFile.isEmpty() || itemImageFiles.isEmpty()) {
+            return ApiResponse.fail(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getMessage());
+        }
+        coordinateLookAdminService.create(requestDto, coordinateLookImageFile, itemImageFiles);
+        return ApiResponse.success();
     }
 
     @GetMapping("/{id}")
     @Operation(summary = "Read One CoordinateLook With Items", description = "코디룩 단건 조회. 해당 코디룩 안에 속한 아이템을 함께 반환한다.")
-    public ResponseEntity<CoordinateLookDetailsResponse> getCoordinateLook(@PathVariable Long id) {
+    public ApiResponse getCoordinateLook(@PathVariable Long id) {
         Optional<CoordinateLook> optional = Optional.ofNullable(coordinateLookAdminService.findById(id));
 
         return optional.map(coordinateLook -> {
             CoordinateLookDetailsResponse response = CoordinateLookDetailsResponse.of(coordinateLook,
                     coordinateLook.getItems());
-            return ResponseEntity.ok(response);
-        }).orElse(ResponseEntity.notFound().build());
-
+            return ApiResponse.success(response);
+        }).orElse(ApiResponse.fail(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getMessage()));
     }
 
     @GetMapping
     @Operation(summary = "Read All CoordinateLook", description = "코디룩 정보 전체 조회")
-    public ResponseEntity<List<CoordinateLookResponse>> getCoordinateLooks() {
+    public ApiResponse<List<CoordinateLookResponse>> getCoordinateLooks() {
         List<CoordinateLook> coordinateLooks = coordinateLookAdminService.findAll();
-
-        if (coordinateLooks.isEmpty()) {
-            return ResponseEntity.notFound().build();
-        }
-
-        List<CoordinateLookResponse> coordinateLookResponses = coordinateLooks.stream()
+        List<CoordinateLookResponse> response = coordinateLooks.stream()
                 .map(CoordinateLookResponse::of)
                 .collect(Collectors.toList());
 
-        return ResponseEntity.ok(coordinateLookResponses);
+        return ApiResponse.success(response);
     }
 
     @GetMapping("/style-points/{id}")
     @Operation(summary = "Read All CoordinateLooks By StylePointId", description = "스타일포인트 ID에 해당하는 코디룩 목록 전체 조회")
-    public ResponseEntity<List<CoordinateLookResponse>> getCoordinateLooksByStylePointId(@PathVariable Long id) {
+    public ApiResponse<List<CoordinateLookResponse>> getCoordinateLooksByStylePointId(@PathVariable Long id) {
         List<CoordinateLook> coordinateLooks = coordinateLookAdminService.findByStylePointId(id);
-        List<CoordinateLookResponse> coordinateLookResponses = coordinateLooks.stream()
+        List<CoordinateLookResponse> response = coordinateLooks.stream()
                 .map(CoordinateLookResponse::of)
                 .collect(Collectors.toList());
 
-        return Optional.of(coordinateLookResponses)
-                .filter(list -> !list.isEmpty())
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.status(HttpStatus.NO_CONTENT).body(coordinateLookResponses));
+        return ApiResponse.success(response);
     }
 
     @PutMapping("/{id}")
     @Operation(summary = "Update CoordinateLook", description = "코디룩 정보 수정")
-    public ResponseEntity<CoordinateLookResponse> update(@PathVariable Long id,
-                                                         @RequestBody CoordinateLookRequest requestDto) {
+    public ApiResponse update(@PathVariable Long id, @RequestPart CoordinateLookRequest requestDto,
+                              @RequestPart(value = "coordinate-looks_imageFile", required = false) MultipartFile coordinateLookImageFile)
+            throws Exception {
+
         if (id == null) {
-            return ResponseEntity.badRequest().build();
+            return ApiResponse.fail(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getMessage());
         }
 
-        CoordinateLook updated = coordinateLookAdminService.update(id, requestDto);
-        return ResponseEntity.ok(CoordinateLookResponse.of(updated));
+        CoordinateLook coordinateLook = coordinateLookAdminService.update(id, requestDto, coordinateLookImageFile);
+        CoordinateLookResponse response = CoordinateLookResponse.of(coordinateLook);
+        return ApiResponse.success(response);
+    }
+
+    @PutMapping("/{coordinateLookId}/items/{itemId}")
+    @Operation(summary = "Update Item From CoordinateLookId", description = "코디룩에 속한 아이템 수정")
+    public ApiResponse updateItemFromCoordinateLook(@PathVariable Long coordinateLookId,
+                                                    @PathVariable Long itemId,
+                                                    @RequestPart ItemRequest requestDto,
+                                                    @RequestPart(value = "item_imageFile", required = false) MultipartFile itemImageFile)
+            throws IOException {
+        if(coordinateLookId == null || itemId == null) {
+            return ApiResponse.fail(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getMessage());
+        }
+
+        CoordinateLook coordinateLook = coordinateLookAdminService.updateItem(coordinateLookId, itemId, requestDto, itemImageFile);
+        CoordinateLookResponse response = CoordinateLookResponse.of(coordinateLook);
+        return ApiResponse.success(response);
     }
 
     @DeleteMapping("/{coordinateLookId}/items/{itemId}")
     @Operation(summary = "Delete Item From CoordinateLookId", description = "코디룩에 속한 아이템 삭제")
-    public ResponseEntity<Void> deleteItemFromCoordinateLook(@PathVariable Long coordinateLookId,
+    public ApiResponse<Void> deleteItemFromCoordinateLook(@PathVariable Long coordinateLookId,
                                                              @PathVariable Long itemId) {
         coordinateLookAdminService.deleteItemFromCoordinateLook(coordinateLookId, itemId);
-        return ResponseEntity.ok().build();
+        return ApiResponse.success();
     }
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Delete CoordinateLook ", description = "코디룩 정보 삭제")
-    public ResponseEntity<Void> delete(@PathVariable Long id) {
-        coordinateLookAdminService.deleteById(id);
-        return ResponseEntity.ok().build();
+    public ApiResponse<Void> delete(@PathVariable Long id) {
+        coordinateLookAdminService.delete(id);
+        return ApiResponse.success();
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/coordinatelook/domain/CoordinateLook.java
+++ b/src/main/java/com/thekey/stylekeyserver/coordinatelook/domain/CoordinateLook.java
@@ -1,6 +1,7 @@
 package com.thekey.stylekeyserver.coordinatelook.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.thekey.stylekeyserver.image.domain.Image;
 import com.thekey.stylekeyserver.item.domain.Item;
 import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
 import java.util.ArrayList;
@@ -26,8 +27,9 @@ public class CoordinateLook {
     @Column(name = "coordinate_look_title")
     private String title;
 
-    @Column(name = "coordinate_look_image")
-    private String image;
+    @OneToOne
+    @JoinColumn(name = "coordinate_look_image_id")
+    private Image image;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "style_point_id")
@@ -39,20 +41,26 @@ public class CoordinateLook {
     private List<Item> items = new ArrayList<>();
 
     @Builder
-    public CoordinateLook(String title, String image, StylePoint stylePoint) {
+    public CoordinateLook(String title, Image image, StylePoint stylePoint) {
         this.title = title;
         this.image = image;
         this.stylePoint = stylePoint;
     }
 
-    public void update(String title, String image, StylePoint stylePoint) {
+    public void update(String title, StylePoint stylePoint) {
         this.title = title;
-        this.image = image;
         this.stylePoint = stylePoint;
     }
 
     public void addItem(Item item) {
         items.add(item);
         item.setCoordinateLook(this);
+    }
+
+    public void setImage(Image newImage) {
+        if(this.image != null) {
+            this.image.setUnused();
+        }
+        this.image = newImage;
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/coordinatelook/dto/request/CoordinateLookRequest.java
+++ b/src/main/java/com/thekey/stylekeyserver/coordinatelook/dto/request/CoordinateLookRequest.java
@@ -17,22 +17,18 @@ import lombok.NoArgsConstructor;
 @JsonNaming(SnakeCaseStrategy.class)
 public class CoordinateLookRequest {
 
-    @Schema(description = "코디룩 제목", example = "유니크 코디룩1")
+    @Schema(description = "코디룩 제목")
     private String title;
 
-    @Schema(description = "코디룩 이미지 URL", example = "coordinate_look_image")
-    private String image;
-
-    @Schema(description = "스타일포인트 ID", example = "1")
+    @Schema(description = "스타일포인트 ID")
     private Long stylePointId;
 
     @Schema(description = "아이템 목록")
     private List<ItemRequest> items;
 
     @Builder
-    public CoordinateLookRequest(String title, String image, Long stylePointId, List<ItemRequest> items) {
+    public CoordinateLookRequest(String title, Long stylePointId, List<ItemRequest> items) {
         this.title = title;
-        this.image = image;
         this.stylePointId = stylePointId;
         this.items = items;
     }
@@ -45,7 +41,6 @@ public class CoordinateLookRequest {
     public CoordinateLook toEntity(StylePoint stylePoint) {
         return CoordinateLook.builder()
                 .title(this.title)
-                .image(this.image)
                 .stylePoint(stylePoint)
                 .build();
     }

--- a/src/main/java/com/thekey/stylekeyserver/coordinatelook/dto/response/CoordinateLookDetailsResponse.java
+++ b/src/main/java/com/thekey/stylekeyserver/coordinatelook/dto/response/CoordinateLookDetailsResponse.java
@@ -25,7 +25,7 @@ public class CoordinateLookDetailsResponse {
     private String title;
 
     @Schema(description = "코디룩 이미지 URL", example = "coordinate_look_image")
-    private String image;
+    private String imageUrl;
 
     @Schema(description = "스타일포인트 ID", example = "1")
     private Long stylePointId;
@@ -34,10 +34,10 @@ public class CoordinateLookDetailsResponse {
     private List<ItemResponse> items;
 
     @Builder
-    public CoordinateLookDetailsResponse(Long id, String title, String image, Long stylePointId, List<ItemResponse> items) {
+    public CoordinateLookDetailsResponse(Long id, String title, String imageUrl, Long stylePointId, List<ItemResponse> items) {
         this.id = id;
         this.title = title;
-        this.image = image;
+        this.imageUrl = imageUrl;
         this.stylePointId = stylePointId;
         this.items = items;
     }
@@ -52,10 +52,12 @@ public class CoordinateLookDetailsResponse {
                 .map(ItemResponse::of)
                 .collect(Collectors.toList());
 
+        String imageUrl = coordinateLook.getImage().getUrl();
+
         return CoordinateLookDetailsResponse.builder()
                 .id(coordinateLook.getId())
                 .title(coordinateLook.getTitle())
-                .image(coordinateLook.getImage())
+                .imageUrl(imageUrl)
                 .stylePointId(coordinateLook.getStylePoint().getId())
                 .items(itemResponses)
                 .build();

--- a/src/main/java/com/thekey/stylekeyserver/coordinatelook/dto/response/CoordinateLookResponse.java
+++ b/src/main/java/com/thekey/stylekeyserver/coordinatelook/dto/response/CoordinateLookResponse.java
@@ -13,31 +13,33 @@ import lombok.NoArgsConstructor;
 @JsonNaming(SnakeCaseStrategy.class)
 public class CoordinateLookResponse {
 
-    @Schema(description = "코디룩 ID", example = "1")
+    @Schema(description = "코디룩 ID")
     private Long id;
 
-    @Schema(description = "코디룩 제목", example = "유니크 코디룩1")
+    @Schema(description = "코디룩 제목")
     private String title;
 
-    @Schema(description = "코디룩 이미지 URL", example = "coordinate_look_image")
-    private String image;
+    @Schema(description = "코디룩 이미지 URL")
+    private String coordinateLookImageUrl;
 
-    @Schema(description = "스타일포인트 ID", example = "1")
+    @Schema(description = "스타일포인트 ID")
     private Long stylePointId;
 
     @Builder
-    public CoordinateLookResponse(Long id, String title, String image, Long stylePointId) {
+    public CoordinateLookResponse(Long id, String title, String coordinateLookImageUrl, Long stylePointId) {
         this.id = id;
         this.title = title;
-        this.image = image;
+        this.coordinateLookImageUrl = coordinateLookImageUrl;
         this.stylePointId = stylePointId;
     }
 
     public static CoordinateLookResponse of(CoordinateLook coordinateLook) {
+        String imageUrl = coordinateLook.getImage().getUrl();
+
         return CoordinateLookResponse.builder()
                 .id(coordinateLook.getId())
                 .title(coordinateLook.getTitle())
-                .image(coordinateLook.getImage())
+                .coordinateLookImageUrl(imageUrl)
                 .stylePointId(coordinateLook.getStylePoint().getId())
                 .build();
     }

--- a/src/main/java/com/thekey/stylekeyserver/coordinatelook/service/CoordinateLookAdminService.java
+++ b/src/main/java/com/thekey/stylekeyserver/coordinatelook/service/CoordinateLookAdminService.java
@@ -5,6 +5,8 @@ import com.thekey.stylekeyserver.coordinatelook.dto.response.CoordinateLookRespo
 import com.thekey.stylekeyserver.coordinatelook.dto.request.CoordinateLookRequest;
 import com.thekey.stylekeyserver.item.dto.request.ItemRequest;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -26,7 +28,7 @@ public interface CoordinateLookAdminService {
     CoordinateLook updateItem(Long coordinateLookId, Long itemId, ItemRequest requestDto,
                               MultipartFile itemImageFile) throws IOException;
 
-    void delete(Long id);
+    void delete(Long id) throws MalformedURLException, UnsupportedEncodingException;
 
     void deleteItemFromCoordinateLook(Long coordinateLookId, Long itemId);
 }

--- a/src/main/java/com/thekey/stylekeyserver/coordinatelook/service/CoordinateLookAdminService.java
+++ b/src/main/java/com/thekey/stylekeyserver/coordinatelook/service/CoordinateLookAdminService.java
@@ -3,11 +3,16 @@ package com.thekey.stylekeyserver.coordinatelook.service;
 import com.thekey.stylekeyserver.coordinatelook.domain.CoordinateLook;
 import com.thekey.stylekeyserver.coordinatelook.dto.response.CoordinateLookResponse;
 import com.thekey.stylekeyserver.coordinatelook.dto.request.CoordinateLookRequest;
+import com.thekey.stylekeyserver.item.dto.request.ItemRequest;
+import java.io.IOException;
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface CoordinateLookAdminService {
 
-    CoordinateLook create(CoordinateLookRequest requestDto);
+    CoordinateLook create(CoordinateLookRequest requestDto,
+                          MultipartFile coordinateLookImageFile,
+                          List<MultipartFile> itemImageFiles) throws Exception;
 
     CoordinateLook findById(Long id);
 
@@ -15,13 +20,13 @@ public interface CoordinateLookAdminService {
 
     List<CoordinateLook> findByStylePointId(Long id);
 
-    CoordinateLook update(Long id, CoordinateLookRequest requestDto);
+    CoordinateLook update(Long id, CoordinateLookRequest requestDto,
+                          MultipartFile coordinateLookImageFile) throws IOException;
 
-    void deleteById(Long id);
+    CoordinateLook updateItem(Long coordinateLookId, Long itemId, ItemRequest requestDto,
+                              MultipartFile itemImageFile) throws IOException;
+
+    void delete(Long id);
 
     void deleteItemFromCoordinateLook(Long coordinateLookId, Long itemId);
-
-//    CoordinateLookResponse convertToDto(CoordinateLook coordinateLook);
-
-//    CoordinateLookResponse convertToResponseDto(CoordinateLook coordinateLook);
 }

--- a/src/main/java/com/thekey/stylekeyserver/coordinatelook/service/CoordinateLookAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/coordinatelook/service/CoordinateLookAdminServiceImpl.java
@@ -13,7 +13,7 @@ import com.thekey.stylekeyserver.item.domain.Item;
 import com.thekey.stylekeyserver.item.dto.request.ItemRequest;
 import com.thekey.stylekeyserver.item.service.ItemAdminService;
 import com.thekey.stylekeyserver.common.s3.S3ErrorMessage;
-import com.thekey.stylekeyserver.common.s3.S3Service;
+import com.thekey.stylekeyserver.common.s3.service.S3Service;
 import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
 import com.thekey.stylekeyserver.stylepoint.service.StylePointAdminService;
 import java.io.IOException;

--- a/src/main/java/com/thekey/stylekeyserver/coordinatelook/service/CoordinateLookAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/coordinatelook/service/CoordinateLookAdminServiceImpl.java
@@ -4,50 +4,85 @@ import com.thekey.stylekeyserver.coordinatelook.CoordinateLookErrorMessage;
 import com.thekey.stylekeyserver.coordinatelook.domain.CoordinateLook;
 import com.thekey.stylekeyserver.coordinatelook.dto.request.CoordinateLookRequest;
 import com.thekey.stylekeyserver.coordinatelook.repository.CoordinateLookRepository;
+import com.thekey.stylekeyserver.image.domain.Image;
+import com.thekey.stylekeyserver.image.domain.Type;
+import com.thekey.stylekeyserver.image.repository.ImageRepository;
 import com.thekey.stylekeyserver.item.ItemErrorMessage;
 import com.thekey.stylekeyserver.item.domain.Item;
 import com.thekey.stylekeyserver.item.dto.request.ItemRequest;
 import com.thekey.stylekeyserver.item.service.ItemAdminService;
+import com.thekey.stylekeyserver.s3.S3ErrorMessage;
+import com.thekey.stylekeyserver.s3.S3Service;
 import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
 import com.thekey.stylekeyserver.stylepoint.service.StylePointAdminService;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class CoordinateLookAdminServiceImpl implements CoordinateLookAdminService {
 
     private final CoordinateLookRepository coordinateLookRepository;
     private final StylePointAdminService stylePointAdminService;
     private final ItemAdminService itemAdminService;
+    private final ImageRepository imageRepository;
+    private final S3Service s3Service;
 
     @Override
-    public CoordinateLook create(CoordinateLookRequest requestDto) {
+    @Transactional
+    public CoordinateLook create(CoordinateLookRequest requestDto,
+                                 MultipartFile coordinateLookImageFile,
+                                 List<MultipartFile> itemImageFiles) throws Exception {
+
         StylePoint stylePoint = stylePointAdminService.findById(requestDto.getStylePointId());
-        CoordinateLook savedCoordinateLook = coordinateLookRepository.save(requestDto.toEntity(stylePoint));
+        CoordinateLook coordinateLook = requestDto.toEntity(stylePoint);
 
-        if (requestDto.getItems() != null) {
-            List<Item> items = new ArrayList<>();
-            for (ItemRequest itemDto : requestDto.getItems()) {
-                Item createdItem = itemAdminService.create(itemDto);
-                items.add(createdItem);
+        List<ItemRequest> itemRequests = requestDto.getItems();
+        Map<Long, MultipartFile> itemImageFilesMap = new HashMap<>();
+
+        // Map에 아이템 ID와 이미지 파일을 매핑
+        for (MultipartFile file : itemImageFiles) {
+            Long imageId = getItemIdFromFileName(file);
+            itemImageFilesMap.put(imageId, file);
+        }
+
+        List<Item> items = new ArrayList<>();
+        for (ItemRequest itemDto : itemRequests) {
+            Long itemId = itemDto.getId();
+            MultipartFile itemImageFile = itemImageFilesMap.get(itemId);
+
+            if (itemImageFile == null) {
+                throw new IllegalArgumentException(S3ErrorMessage.NO_FILE_ITEM_ID.getMessage() + itemId);
             }
 
-            for (Item item : items) {
-                savedCoordinateLook.addItem(item);
-            }
+            Item item = itemAdminService.create(itemDto, itemImageFile);
+            items.add(item);
+        }
+
+        Image coordinateImage = s3Service.uploadFile(coordinateLookImageFile, Type.COORDINATE_LOOK);
+        imageRepository.save(coordinateImage);
+        coordinateLook.setImage(coordinateImage);
+
+        CoordinateLook savedCoordinateLook = coordinateLookRepository.save(coordinateLook);
+
+        for (Item item : items) {
+            savedCoordinateLook.addItem(item);
         }
         return savedCoordinateLook;
     }
 
     @Override
+    @Transactional(readOnly = true)
     public CoordinateLook findById(Long id) {
         return coordinateLookRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(
@@ -55,42 +90,86 @@ public class CoordinateLookAdminServiceImpl implements CoordinateLookAdminServic
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<CoordinateLook> findAll() {
         return coordinateLookRepository.findAll();
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<CoordinateLook> findByStylePointId(Long id) {
         return coordinateLookRepository.findCoordinateLookByStylePointId(id);
     }
 
     @Override
-    public CoordinateLook update(Long id, CoordinateLookRequest requestDto) {
+    @Transactional
+    public CoordinateLook update(Long id, CoordinateLookRequest requestDto,
+                                 MultipartFile coordinateLookImageFile) throws IOException {
+
         CoordinateLook coordinateLook = coordinateLookRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(
                         CoordinateLookErrorMessage.NOT_FOUND_COORDINATE_LOOK.get() + id));
         StylePoint stylePoint = stylePointAdminService.findById(requestDto.getStylePointId());
 
-        coordinateLook.update(
-                requestDto.getTitle(),
-                requestDto.getImage(),
-                requestDto.toEntity(stylePoint).getStylePoint());
+        if (!coordinateLookImageFile.isEmpty()) {
+            Image coordinateLookOldImage = coordinateLook.getImage();
 
-        if (requestDto.getItems() != null) {
-            for (ItemRequest itemRequestDto : requestDto.getItems()) {
-                itemAdminService.update(itemRequestDto.getId(), itemRequestDto);
+            if (coordinateLookOldImage != null) {
+                coordinateLookOldImage.setUnused();
+                imageRepository.save(coordinateLookOldImage);
+
+                Image newImage = s3Service.uploadFile(coordinateLookImageFile, Type.COORDINATE_LOOK);
+                imageRepository.save(newImage);
+
+                coordinateLook.setImage(newImage);
+                coordinateLookRepository.save(coordinateLook);
             }
         }
 
+        coordinateLook.update(
+                requestDto.getTitle(),
+                stylePoint);
         return coordinateLook;
     }
 
     @Override
-    public void deleteById(Long id) {
+    @Transactional
+    public CoordinateLook updateItem(Long coordinateLookId, Long itemId, ItemRequest requestDto,
+                                     MultipartFile itemImageFile) throws IOException {
+
+        CoordinateLook coordinateLook = coordinateLookRepository.findById(coordinateLookId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        CoordinateLookErrorMessage.NOT_FOUND_COORDINATE_LOOK.get() + coordinateLookId));
+        itemAdminService.update(coordinateLookId, itemId, requestDto, itemImageFile);
+        return coordinateLook;
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long id) {
+        CoordinateLook coordinateLook = coordinateLookRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(CoordinateLookErrorMessage.NOT_FOUND_COORDINATE_LOOK.get() + id));
+
+        List<Item> items = coordinateLook.getItems();
+        for(Item item : items) {
+            Image image = item.getImage();
+            if(image != null) {
+                image.setUnused();
+                imageRepository.save(image);
+            }
+        }
+
+        Image image = coordinateLook.getImage();
+
+        if(image != null) {
+            image.setUnused();
+            imageRepository.save(image);
+        }
         coordinateLookRepository.deleteById(id);
     }
 
     @Override
+    @Transactional
     public void deleteItemFromCoordinateLook(Long coordinateLookId, Long itemId) {
         CoordinateLook coordinateLook = coordinateLookRepository.findById(coordinateLookId)
                 .orElseThrow(() -> new EntityNotFoundException(
@@ -116,4 +195,11 @@ public class CoordinateLookAdminServiceImpl implements CoordinateLookAdminServic
         }
     }
 
+
+    private Long getItemIdFromFileName(MultipartFile fileName) {
+        String filenameWithoutExtension = fileName.getOriginalFilename()
+                .substring(0, fileName.getOriginalFilename().lastIndexOf('.'));
+        String[] parts = filenameWithoutExtension.split("_");
+        return Long.valueOf(parts[parts.length - 1]);
+    }
 }

--- a/src/main/java/com/thekey/stylekeyserver/image/domain/Image.java
+++ b/src/main/java/com/thekey/stylekeyserver/image/domain/Image.java
@@ -42,8 +42,8 @@ public class Image {
     @Column(name = "image_is_used")
     private Boolean isUsed;
 
-    @Column(name = "delete_at")
-    private LocalDateTime deleteAt;
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
     @OneToOne(mappedBy = "image")
     private Brand brand;
@@ -64,6 +64,6 @@ public class Image {
 
     public void setUnused() {
         this.isUsed = false;
-        this.deleteAt = LocalDateTime.now().plusDays(1);
+        this.deletedAt = LocalDateTime.now().plusDays(1);
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/image/domain/Image.java
+++ b/src/main/java/com/thekey/stylekeyserver/image/domain/Image.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -20,6 +21,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "image")
 public class Image {
 
     @Id

--- a/src/main/java/com/thekey/stylekeyserver/image/domain/Image.java
+++ b/src/main/java/com/thekey/stylekeyserver/image/domain/Image.java
@@ -1,6 +1,8 @@
 package com.thekey.stylekeyserver.image.domain;
 
 import com.thekey.stylekeyserver.brand.domain.Brand;
+import com.thekey.stylekeyserver.coordinatelook.domain.CoordinateLook;
+import com.thekey.stylekeyserver.item.domain.Item;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -43,6 +45,12 @@ public class Image {
 
     @OneToOne(mappedBy = "image")
     private Brand brand;
+
+    @OneToOne(mappedBy = "image")
+    private Item item;
+
+    @OneToOne(mappedBy = "image")
+    private CoordinateLook coordinateLook;
 
     @Builder
     public Image(String url, Type type, String fileName, Boolean isUsed) {

--- a/src/main/java/com/thekey/stylekeyserver/image/service/ImageBatchService.java
+++ b/src/main/java/com/thekey/stylekeyserver/image/service/ImageBatchService.java
@@ -2,31 +2,33 @@ package com.thekey.stylekeyserver.image.service;
 
 import com.thekey.stylekeyserver.image.domain.Image;
 import com.thekey.stylekeyserver.image.repository.ImageRepository;
-import com.thekey.stylekeyserver.s3.S3Service;
+import com.thekey.stylekeyserver.common.s3.S3Service;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 @Service
+@Profile("prod")
 @RequiredArgsConstructor
 public class ImageBatchService {
     private final ImageRepository imageRepository;
     private final S3Service s3Service;
 
-    @Scheduled(cron = "0 0 0 * * *")  // 매일 새벽 0시에 실행
-    public void deleteUnusedImages() throws MalformedURLException, UnsupportedEncodingException {
-        List<Image> unusedImages = imageRepository.findByIsUsed(false);
-
-        for (Image image : unusedImages) {
-            // 이미지가 24시간 이상 사용되지 않았다면 S3에서 이미지 파일 삭제
-            if (image.getDeleteAt().isBefore(LocalDateTime.now())) {
-                s3Service.deleteFile(image.getUrl(), image.getType());
-                imageRepository.delete(image);
-            }
-        }
-    }
+//    @Scheduled(cron = "0 0 0 * * *")  // 매일 새벽 0시에 실행
+//    public void deleteUnusedImages() throws MalformedURLException, UnsupportedEncodingException {
+//        List<Image> unusedImages = imageRepository.findByIsUsed(false);
+//
+//        for (Image image : unusedImages) {
+//            // 이미지가 24시간 이상 사용되지 않았다면 S3에서 이미지 파일 삭제
+//            if (image.getDeletedAt().isBefore(LocalDateTime.now())) {
+//                s3Service.deleteFile(image.getUrl(), image.getType());
+//                imageRepository.delete(image);
+//            }
+//        }
+//    }
 }

--- a/src/main/java/com/thekey/stylekeyserver/image/service/ImageBatchService.java
+++ b/src/main/java/com/thekey/stylekeyserver/image/service/ImageBatchService.java
@@ -19,16 +19,16 @@ public class ImageBatchService {
     private final ImageRepository imageRepository;
     private final S3Service s3Service;
 
-//    @Scheduled(cron = "0 0 0 * * *")  // 매일 새벽 0시에 실행
-//    public void deleteUnusedImages() throws MalformedURLException, UnsupportedEncodingException {
-//        List<Image> unusedImages = imageRepository.findByIsUsed(false);
-//
-//        for (Image image : unusedImages) {
-//            // 이미지가 24시간 이상 사용되지 않았다면 S3에서 이미지 파일 삭제
-//            if (image.getDeletedAt().isBefore(LocalDateTime.now())) {
-//                s3Service.deleteFile(image.getUrl(), image.getType());
-//                imageRepository.delete(image);
-//            }
-//        }
-//    }
+    @Scheduled(cron = "0 0 0 * * *")  // 매일 새벽 0시에 실행
+    public void deleteUnusedImages() throws MalformedURLException, UnsupportedEncodingException {
+        List<Image> unusedImages = imageRepository.findByIsUsed(false);
+
+        for (Image image : unusedImages) {
+            // 이미지가 24시간 이상 사용되지 않았다면 S3에서 이미지 파일 삭제
+            if (image.getDeletedAt().isBefore(LocalDateTime.now())) {
+                s3Service.deleteFile(image.getUrl(), image.getType());
+                imageRepository.delete(image);
+            }
+        }
+    }
 }

--- a/src/main/java/com/thekey/stylekeyserver/image/service/ImageBatchService.java
+++ b/src/main/java/com/thekey/stylekeyserver/image/service/ImageBatchService.java
@@ -2,7 +2,7 @@ package com.thekey.stylekeyserver.image.service;
 
 import com.thekey.stylekeyserver.image.domain.Image;
 import com.thekey.stylekeyserver.image.repository.ImageRepository;
-import com.thekey.stylekeyserver.common.s3.S3Service;
+import com.thekey.stylekeyserver.common.s3.service.S3Service;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.time.LocalDateTime;

--- a/src/main/java/com/thekey/stylekeyserver/image/service/ImageService.java
+++ b/src/main/java/com/thekey/stylekeyserver/image/service/ImageService.java
@@ -1,0 +1,30 @@
+package com.thekey.stylekeyserver.image.service;
+
+import com.thekey.stylekeyserver.common.s3.S3Service;
+import com.thekey.stylekeyserver.image.domain.Image;
+import com.thekey.stylekeyserver.image.repository.ImageRepository;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Service
+@Profile("dev")
+@RequiredArgsConstructor
+public class ImageService {
+    private final ImageRepository imageRepository;
+    private final S3Service s3Service;
+
+    public void deleteUnusedImages() throws MalformedURLException, UnsupportedEncodingException {
+        List<Image> unusedImages = imageRepository.findByIsUsed(false);
+
+        for (Image image : unusedImages) {
+            // 이미지를 S3에서 즉시 삭제
+            s3Service.deleteFile(image.getUrl(), image.getType());
+            imageRepository.delete(image);
+        }
+
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/image/service/ImageService.java
+++ b/src/main/java/com/thekey/stylekeyserver/image/service/ImageService.java
@@ -1,6 +1,6 @@
 package com.thekey.stylekeyserver.image.service;
 
-import com.thekey.stylekeyserver.common.s3.S3Service;
+import com.thekey.stylekeyserver.common.s3.service.S3Service;
 import com.thekey.stylekeyserver.image.domain.Image;
 import com.thekey.stylekeyserver.image.repository.ImageRepository;
 import java.io.UnsupportedEncodingException;

--- a/src/main/java/com/thekey/stylekeyserver/item/controller/ItemAdminController.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/controller/ItemAdminController.java
@@ -1,5 +1,7 @@
 package com.thekey.stylekeyserver.item.controller;
 
+import com.thekey.stylekeyserver.common.ApiResponse;
+import com.thekey.stylekeyserver.common.ErrorCode;
 import com.thekey.stylekeyserver.coordinatelook.service.CoordinateLookAdminService;
 import com.thekey.stylekeyserver.item.domain.Item;
 import com.thekey.stylekeyserver.item.dto.response.ItemResponse;
@@ -8,8 +10,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,44 +29,34 @@ public class ItemAdminController {
 
     @GetMapping("/{id}")
     @Operation(summary = "Read One Item", description = "아이템 정보 단건 조회")
-    public ResponseEntity<ItemResponse> getItem(@PathVariable Long id) {
+    public ApiResponse getItem(@PathVariable Long id) {
         Optional<Item> optional = Optional.ofNullable(itemAdminService.findById(id));
 
-        return optional
-                .map(item -> {
-                    ItemResponse response = ItemResponse.of(item);
-                    return ResponseEntity.ok(response);
-                }).orElse(ResponseEntity.notFound().build());
+        return optional.map(item -> {
+            ItemResponse response = ItemResponse.of(item);
+            return ApiResponse.success(response);
+        }).orElse(ApiResponse.fail(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getMessage()));
     }
 
     @GetMapping
     @Operation(summary = "Read All Items", description = "아이템 정보 전체 조회")
-    public ResponseEntity<List<ItemResponse>> getItems() {
+    public ApiResponse<List<ItemResponse>> getItems() {
         List<Item> items = itemAdminService.findAll();
-
-        if (items.isEmpty()) {
-            return ResponseEntity.notFound().build();
-        }
         List<ItemResponse> responses = items.stream()
                 .map(ItemResponse::of)
-                .toList();
+                .collect(Collectors.toList());
 
-        return ResponseEntity.ok(responses);
+        return ApiResponse.success(responses);
     }
 
     @GetMapping("/coordinate-looks/{id}")
     @Operation(summary = "Read All Items By CoordinateLookId", description = "코디룩 ID에 해당하는 아이템 목록 전체 조회")
-    public ResponseEntity<List<ItemResponse>> getItemsByCoordinateLookId(@PathVariable Long id) {
+    public ApiResponse<List<ItemResponse>> getItemsByCoordinateLookId(@PathVariable Long id) {
         List<Item> items = itemAdminService.findAllByCoordinateLookId(id, coordinateLookAdminService);
-
-        if (items.isEmpty()) {
-            return ResponseEntity.notFound().build();
-        }
-
         List<ItemResponse> responses = items.stream()
                 .map(ItemResponse::of)
                 .toList();
 
-        return ResponseEntity.ok(responses);
+        return ApiResponse.success(responses);
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/item/controller/ItemAdminController.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/controller/ItemAdminController.java
@@ -1,7 +1,7 @@
 package com.thekey.stylekeyserver.item.controller;
 
-import com.thekey.stylekeyserver.common.ApiResponse;
-import com.thekey.stylekeyserver.common.ErrorCode;
+import com.thekey.stylekeyserver.common.exception.ApiResponse;
+import com.thekey.stylekeyserver.common.exception.ErrorCode;
 import com.thekey.stylekeyserver.coordinatelook.service.CoordinateLookAdminService;
 import com.thekey.stylekeyserver.item.domain.Item;
 import com.thekey.stylekeyserver.item.dto.response.ItemResponse;

--- a/src/main/java/com/thekey/stylekeyserver/item/domain/Item.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/domain/Item.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "item")
 public class Item {
 
     @Id

--- a/src/main/java/com/thekey/stylekeyserver/item/domain/Item.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/domain/Item.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.thekey.stylekeyserver.brand.domain.Brand;
 import com.thekey.stylekeyserver.category.domain.Category;
 import com.thekey.stylekeyserver.coordinatelook.domain.CoordinateLook;
+import com.thekey.stylekeyserver.image.domain.Image;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -26,8 +27,9 @@ public class Item {
     @Column(name = "item_sales_link")
     private String sales_link;
 
-    @Column(name = "item_image")
-    private String image;
+    @OneToOne
+    @JoinColumn(name = "item_image_id")
+    private Image image;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "brand_id")
@@ -43,7 +45,7 @@ public class Item {
     private Category category;
 
     @Builder
-    public Item(String title, String sales_link, String image, Brand brand, Category category) {
+    public Item(String title, String sales_link, Image image, Brand brand, Category category) {
         this.title = title;
         this.sales_link = sales_link;
         this.image = image;
@@ -51,12 +53,18 @@ public class Item {
         this.category = category;
     }
 
-    public void update(String title, String sales_link, String image, Brand brand, Category category) {
+    public void update(String title, String sales_link, Brand brand, Category category) {
         this.title = title;
         this.sales_link = sales_link;
-        this.image = image;
         this.brand = brand;
         this.category = category;
+    }
+
+    public void setImage(Image newImage) {
+        if(this.image != null) {
+            this.image.setUnused();
+        }
+        this.image = newImage;
     }
 
     public void setCoordinateLook(CoordinateLook coordinateLook) {

--- a/src/main/java/com/thekey/stylekeyserver/item/dto/request/ItemRequest.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/dto/request/ItemRequest.java
@@ -15,40 +15,34 @@ import lombok.NoArgsConstructor;
 @JsonNaming(SnakeCaseStrategy.class)
 public class ItemRequest {
 
-    @Schema(description = "아이템 ID", example = "1")
+    @Schema(description = "아이템 ID")
     private Long id;
 
-    @Schema(description = "아이템 이름", example = "유니크 아이템1")
+    @Schema(description = "아이템 이름")
     private String title;
 
-    @Schema(description = "아이템 판매 링크", example = "http://m.odlyworkshop.com/product/good-grief-mesh-tee/374/category/72/display/1/")
+    @Schema(description = "아이템 판매 링크")
     private String sales_link;
 
-    @Schema(description = "아이템 이미지", example = "item_image")
-    private String image;
-
-    @Schema(description = "브랜드 ID", example = "3")
+    @Schema(description = "브랜드 ID")
     private Long brandId;
 
-    @Schema(description = "카테고리 ID", example = "1")
+    @Schema(description = "카테고리 ID")
     private Long categoryId;
 
     @Builder
-    public ItemRequest(Long id, String title, String sales_link, String image, Long brandId, Long categoryId) {
+    public ItemRequest(Long id, String title, String sales_link, Long brandId, Long categoryId) {
         this.id = id;
         this.title = title;
         this.sales_link = sales_link;
-        this.image = image;
         this.brandId = brandId;
         this.categoryId = categoryId;
     }
 
     public Item toEntity(Brand brand, Category category) {
         return Item.builder()
-                .image(this.image)
                 .title(this.title)
                 .sales_link(this.sales_link)
-                .image(this.image)
                 .brand(brand)
                 .category(category)
                 .build();

--- a/src/main/java/com/thekey/stylekeyserver/item/dto/response/ItemResponse.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/dto/response/ItemResponse.java
@@ -13,45 +13,46 @@ import lombok.NoArgsConstructor;
 @JsonNaming(SnakeCaseStrategy.class)
 public class ItemResponse {
 
-    @Schema(description = "아이템 ID", example = "1")
+    @Schema(description = "아이템 ID")
     private Long id;
 
-    @Schema(description = "아이템 이름", example = "유니크 아이템1")
+    @Schema(description = "아이템 이름")
     private String title;
 
-    @Schema(description = "아이템 판매 링크", example = "http://m.odlyworkshop.com/product/good-grief-mesh-tee/374/category/72/display/1/")
+    @Schema(description = "아이템 판매 링크")
     private String sales_link;
 
-    @Schema(description = "아이템 이미지", example = "item_image")
-    private String image;
+    @Schema(description = "아이템 이미지")
+    private String itemImageUrl;
 
-    @Schema(description = "브랜드 ID", example = "3")
+    @Schema(description = "브랜드 ID")
     private Long brandId;
 
-    @Schema(description = "카테고리 ID", example = "1")
+    @Schema(description = "카테고리 ID")
     private Long categoryId;
 
-    @Schema(description = "코디룩 ID", example = "1")
+    @Schema(description = "코디룩 ID")
     private Long coordinateLookId;
 
     @Builder
-    public ItemResponse(Long id, String title, String sales_link, String image, Long brandId, Long categoryId, Long coordinateLookId) {
+    public ItemResponse(Long id, String title, String sales_link, String itemImageUrl, Long brandId, Long categoryId, Long coordinateLookId) {
         this.id = id;
         this.title = title;
         this.sales_link = sales_link;
-        this.image = image;
+        this.itemImageUrl = itemImageUrl;
         this.brandId = brandId;
         this.categoryId = categoryId;
         this.coordinateLookId = coordinateLookId;
     }
 
-    /*TODO: 아이템 단건 조회 시 해당 코디룩 ID도 같이 넣으면 좋을거같음*/
     public static ItemResponse of(Item item) {
+        String imageUrl = item.getImage().getUrl();
+
         return ItemResponse.builder()
                 .id(item.getId())
                 .title(item.getTitle())
                 .sales_link(item.getSales_link())
-                .image(item.getImage())
+                .itemImageUrl(imageUrl)
                 .brandId(item.getBrand().getId())
                 .categoryId(item.getCategory().getId())
                 .coordinateLookId(item.getCoordinateLook().getId())

--- a/src/main/java/com/thekey/stylekeyserver/item/repository/ItemRepository.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/repository/ItemRepository.java
@@ -8,4 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ItemRepository extends JpaRepository<Item, Long> {
 
     List<Item> findItemByCoordinateLook(CoordinateLook coordinateLook);
+    boolean existsByCoordinateLookId(Long coordinateLookId);
 }

--- a/src/main/java/com/thekey/stylekeyserver/item/service/ItemAdminService.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/service/ItemAdminService.java
@@ -3,18 +3,20 @@ package com.thekey.stylekeyserver.item.service;
 import com.thekey.stylekeyserver.coordinatelook.service.CoordinateLookAdminService;
 import com.thekey.stylekeyserver.item.domain.Item;
 import com.thekey.stylekeyserver.item.dto.request.ItemRequest;
+import java.io.IOException;
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface ItemAdminService {
 
-    Item create(ItemRequest requestDto);
+    Item create(ItemRequest requestDto, MultipartFile imageFile) throws IOException;
 
     Item findById(Long id);
 
     List<Item> findAll();
     List<Item> findAllByCoordinateLookId(Long id, CoordinateLookAdminService coordinateLookAdminService);
 
-    Item update(Long id, ItemRequest requestDto);
+    Item update(Long coordinateLookId, Long itemId, ItemRequest requestDto, MultipartFile imageFile) throws IOException;
 
     void delete(Long id);
 

--- a/src/main/java/com/thekey/stylekeyserver/item/service/ItemAdminService.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/service/ItemAdminService.java
@@ -4,6 +4,8 @@ import com.thekey.stylekeyserver.coordinatelook.service.CoordinateLookAdminServi
 import com.thekey.stylekeyserver.item.domain.Item;
 import com.thekey.stylekeyserver.item.dto.request.ItemRequest;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -18,6 +20,6 @@ public interface ItemAdminService {
 
     Item update(Long coordinateLookId, Long itemId, ItemRequest requestDto, MultipartFile imageFile) throws IOException;
 
-    void delete(Long id);
+    void delete(Long id) throws MalformedURLException, UnsupportedEncodingException;
 
 }

--- a/src/main/java/com/thekey/stylekeyserver/item/service/ItemAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/service/ItemAdminServiceImpl.java
@@ -6,69 +6,114 @@ import com.thekey.stylekeyserver.category.domain.Category;
 import com.thekey.stylekeyserver.category.service.CategoryService;
 import com.thekey.stylekeyserver.coordinatelook.domain.CoordinateLook;
 import com.thekey.stylekeyserver.coordinatelook.service.CoordinateLookAdminService;
+import com.thekey.stylekeyserver.image.domain.Image;
+import com.thekey.stylekeyserver.image.domain.Type;
+import com.thekey.stylekeyserver.image.repository.ImageRepository;
 import com.thekey.stylekeyserver.item.ItemErrorMessage;
 import com.thekey.stylekeyserver.item.domain.Item;
 import com.thekey.stylekeyserver.item.dto.request.ItemRequest;
 import com.thekey.stylekeyserver.item.repository.ItemRepository;
+import com.thekey.stylekeyserver.s3.S3Service;
+import java.io.IOException;
 import java.util.List;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class ItemAdminServiceImpl implements ItemAdminService {
 
     private final ItemRepository itemRepository;
+    private final ImageRepository imageRepository;
     private final BrandAdminService brandAdminService;
     private final CategoryService categoryService;
+    private final S3Service s3Service;
 
     @Override
-    public Item create(ItemRequest requestDto) {
+    @Transactional
+    public Item create(ItemRequest requestDto, MultipartFile imageFile) throws IOException {
+        Image image = s3Service.uploadFile(imageFile, Type.ITEM);
+        imageRepository.save(image);
         Category category = categoryService.findById(requestDto.getCategoryId());
         Brand brand = brandAdminService.findById(requestDto.getBrandId());
-        return itemRepository.save(requestDto.toEntity(brand, category));
+
+        Item item = requestDto.toEntity(brand, category);
+        item.setImage(image);
+
+        return itemRepository.save(item);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Item findById(Long id) {
         return itemRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(ItemErrorMessage.NOT_FOUND_ITEM.get() + id));
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<Item> findAll() {
         return itemRepository.findAll();
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<Item> findAllByCoordinateLookId(Long id, CoordinateLookAdminService coordinateLookAdminService) {
         CoordinateLook coordinateLook = coordinateLookAdminService.findById(id);
         return itemRepository.findItemByCoordinateLook(coordinateLook);
     }
 
     @Override
-    public Item update(Long id, ItemRequest requestDto) {
-        Item item = itemRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(ItemErrorMessage.NOT_FOUND_ITEM.get() + id));
+    @Transactional
+    public Item update(Long coordinateLookId, Long itemId, ItemRequest requestDto, MultipartFile imageFile)
+            throws IOException {
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new EntityNotFoundException(ItemErrorMessage.NOT_FOUND_ITEM.get() + itemId));
+
+        if (!itemRepository.existsByCoordinateLookId(coordinateLookId)) {
+            throw new IllegalArgumentException(ItemErrorMessage.NOT_FOUND_ITEM.get());
+        }
 
         Category category = categoryService.findById(requestDto.getCategoryId());
         Brand brand = brandAdminService.findById(requestDto.getBrandId());
 
+        if (!imageFile.isEmpty()) {
+            Image oldImage = item.getImage();
+            if (oldImage != null) {
+                oldImage.setUnused();
+                imageRepository.save(oldImage);
+
+                Image newImage = s3Service.uploadFile(imageFile, Type.ITEM);
+                imageRepository.save(newImage);
+                item.setImage(newImage);
+                itemRepository.save(item);
+            }
+        }
+
         item.update(requestDto.getTitle(),
                 requestDto.getSales_link(),
-                requestDto.getImage(),
-                requestDto.toEntity(brand, category).getBrand(),
-                requestDto.toEntity(brand, category).getCategory());
+                brand,
+                category);
 
         return item;
     }
 
     @Override
+    @Transactional
     public void delete(Long id) {
+        Item item = itemRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(ItemErrorMessage.NOT_FOUND_ITEM.get() + id));
+
+        Image image = item.getImage();
+
+        if (image != null) {
+            image.setUnused();
+            imageRepository.save(image);
+        }
         itemRepository.deleteById(id);
     }
 

--- a/src/main/java/com/thekey/stylekeyserver/item/service/ItemAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/service/ItemAdminServiceImpl.java
@@ -14,7 +14,7 @@ import com.thekey.stylekeyserver.item.ItemErrorMessage;
 import com.thekey.stylekeyserver.item.domain.Item;
 import com.thekey.stylekeyserver.item.dto.request.ItemRequest;
 import com.thekey.stylekeyserver.item.repository.ItemRepository;
-import com.thekey.stylekeyserver.common.s3.S3Service;
+import com.thekey.stylekeyserver.common.s3.service.S3Service;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;

--- a/src/main/java/com/thekey/stylekeyserver/like/controller/LikeCoordinateLookController.java
+++ b/src/main/java/com/thekey/stylekeyserver/like/controller/LikeCoordinateLookController.java
@@ -1,0 +1,55 @@
+package com.thekey.stylekeyserver.like.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.thekey.stylekeyserver.like.dto.request.LikeCoordinateLookRequest;
+import com.thekey.stylekeyserver.like.dto.response.LikeCoordinateLookResponse;
+import com.thekey.stylekeyserver.like.service.LikeCoordinateLookService;
+import com.thekey.stylekeyserver.common.exception.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class LikeCoordinateLookController {
+
+    private final LikeCoordinateLookService likeCoordinateLookService;
+
+    @Operation(summary = "코디룩 좋아요")
+    @PostMapping("/api/coordinate-looks/likes")
+    public ApiResponse<Void> like(@RequestBody LikeCoordinateLookRequest request)
+            throws JsonProcessingException {
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+        System.out.println("유저 정보: " + userId);
+        likeCoordinateLookService.addLikeCoordinateLook(request.getCoordinateLookIds(), userId);
+        return ApiResponse.success();
+    }
+
+    @Operation(summary = "사용자가 좋아요한 코디룩 목록 조회")
+    @GetMapping("/api/users/likes/coordinate-looks")
+    public ApiResponse<List<LikeCoordinateLookResponse>> getLikeCoordinateLooks() throws JsonProcessingException {
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+        return ApiResponse.success(likeCoordinateLookService.getLikeCoordinateLooks(userId));
+    }
+
+    @Operation(summary = "코디룩 별 좋아요 개수 조회")
+    @GetMapping("/api/coordinate-looks/{id}/likes/count")
+    public ApiResponse getLikeCount(@PathVariable Long id) {
+        return ApiResponse.success(likeCoordinateLookService.getLikeCount(id));
+    }
+
+    @Operation(summary = "코디룩 좋아요 취소")
+    @DeleteMapping("/api/coordinate-looks/likes")
+    public ApiResponse<Void> unlike(@RequestBody LikeCoordinateLookRequest request) throws JsonProcessingException {
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+        likeCoordinateLookService.deleteLikeCoordinateLook(request.getCoordinateLookIds(), userId);
+        return ApiResponse.success();
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/like/domain/LikeCoordinateLook.java
+++ b/src/main/java/com/thekey/stylekeyserver/like/domain/LikeCoordinateLook.java
@@ -1,0 +1,30 @@
+package com.thekey.stylekeyserver.like.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.thekey.stylekeyserver.like.dto.response.LikeCoordinateLookResponse;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.redis.core.RedisHash;
+
+@RedisHash("LikeCoordinateLook")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LikeCoordinateLook {
+
+    private String userId;
+    private LikeCoordinateLookResponse coordinateLookResponses;
+    @JsonCreator
+    public LikeCoordinateLook(@JsonProperty("userId") String userId,
+                              @JsonProperty("coordinateLookResponse") LikeCoordinateLookResponse coordinateLookResponse) {
+        this.userId = userId;
+        this.coordinateLookResponses = coordinateLookResponse;
+    }
+
+    @Builder
+    public static LikeCoordinateLook of(String userId, LikeCoordinateLookResponse coordinateLookResponse) {
+        return new LikeCoordinateLook(userId, coordinateLookResponse);
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/like/dto/request/LikeCoordinateLookRequest.java
+++ b/src/main/java/com/thekey/stylekeyserver/like/dto/request/LikeCoordinateLookRequest.java
@@ -1,0 +1,13 @@
+package com.thekey.stylekeyserver.like.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class LikeCoordinateLookRequest {
+
+    @Schema(description = "좋아요한 코디룩 ID 리스트")
+    private List<Long> coordinateLookIds;
+
+}

--- a/src/main/java/com/thekey/stylekeyserver/like/dto/response/LikeCoordinateLookResponse.java
+++ b/src/main/java/com/thekey/stylekeyserver/like/dto/response/LikeCoordinateLookResponse.java
@@ -1,0 +1,45 @@
+package com.thekey.stylekeyserver.like.dto.response;
+
+import com.thekey.stylekeyserver.coordinatelook.domain.CoordinateLook;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class LikeCoordinateLookResponse {
+
+    @Schema(description = "코디룩 ID")
+    private Long id;
+
+    @Schema(description = "코디룩 제목")
+    private String title;
+
+    @Schema(description = "코디룩 이미지 URL")
+    private String coordinateLookImageUrl;
+
+    @Schema(description = "스타일포인트 ID")
+    private Long stylePointId;
+
+    @Builder
+    public LikeCoordinateLookResponse(Long id, String title, String coordinateLookImageUrl, Long stylePointId) {
+        this.id = id;
+        this.title = title;
+        this.coordinateLookImageUrl = coordinateLookImageUrl;
+        this.stylePointId = stylePointId;
+    }
+
+    public static LikeCoordinateLookResponse of(CoordinateLook coordinateLook) {
+        String imageUrl = coordinateLook.getImage().getUrl();
+
+        return LikeCoordinateLookResponse.builder()
+                .id(coordinateLook.getId())
+                .title(coordinateLook.getTitle())
+                .coordinateLookImageUrl(imageUrl)
+                .stylePointId(coordinateLook.getStylePoint().getId())
+                .build();
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/like/service/LikeCoordinateLookService.java
+++ b/src/main/java/com/thekey/stylekeyserver/like/service/LikeCoordinateLookService.java
@@ -1,0 +1,72 @@
+package com.thekey.stylekeyserver.like.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.thekey.stylekeyserver.common.redis.RedisService;
+import com.thekey.stylekeyserver.coordinatelook.CoordinateLookErrorMessage;
+import com.thekey.stylekeyserver.coordinatelook.domain.CoordinateLook;
+import com.thekey.stylekeyserver.coordinatelook.repository.CoordinateLookRepository;
+import com.thekey.stylekeyserver.like.dto.response.LikeCoordinateLookResponse;
+import jakarta.persistence.EntityNotFoundException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LikeCoordinateLookService {
+
+    private final CoordinateLookRepository coordinateLookRepository;
+    private final RedisService redisService;
+
+
+    @Transactional
+    public void addLikeCoordinateLook(List<Long> coordinateLookIds, String userId)
+            throws JsonProcessingException {
+
+        List<LikeCoordinateLookResponse> likeCoordinateLookResponses = new ArrayList<>();
+        for (Long coordinateLookId : coordinateLookIds) {
+            CoordinateLook coordinateLook = coordinateLookRepository.findById(coordinateLookId)
+                    .orElseThrow(() -> new EntityNotFoundException(
+                            CoordinateLookErrorMessage.NOT_FOUND_COORDINATE_LOOK.get()
+                    ));
+
+            LikeCoordinateLookResponse likeCoordinateLookResponse = LikeCoordinateLookResponse.of(coordinateLook);
+            likeCoordinateLookResponses.add(likeCoordinateLookResponse);
+
+            redisService.increaseLikeCount(String.valueOf(coordinateLookId));
+            redisService.setData("like:" + userId, likeCoordinateLookResponses);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<LikeCoordinateLookResponse> getLikeCoordinateLooks(String userId) throws JsonProcessingException {
+        List<LikeCoordinateLookResponse> likeCoordinateLookResponses = redisService.getData("like:" + userId,
+                new TypeReference<List<LikeCoordinateLookResponse>>() {
+                });
+
+        if (likeCoordinateLookResponses != null) {
+            return likeCoordinateLookResponses;
+        } else {
+            return new ArrayList<>();
+        }
+    }
+
+    public Integer getLikeCount(Long coordinateLookId) {
+        return (Integer) redisService.getLikeCount(String.valueOf(coordinateLookId));
+    }
+
+    public void deleteLikeCoordinateLook(List<Long> coordinateLookIds, String userId) throws JsonProcessingException {
+
+        for (Long coordinateLookId : coordinateLookIds) {
+            redisService.decreaseLikeCount(String.valueOf(coordinateLookId));
+        }
+
+        redisService.deleteData("like:" + userId, new TypeReference<List<LikeCoordinateLookResponse>>() {
+        });
+    }
+
+}

--- a/src/main/java/com/thekey/stylekeyserver/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/thekey/stylekeyserver/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -21,7 +21,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import com.thekey.stylekeyserver.auth.entity.UserRefreshToken;
 import com.thekey.stylekeyserver.auth.repository.UserRefreshTokenRepository;
-import com.thekey.stylekeyserver.config.properties.AppProperties;
+import com.thekey.stylekeyserver.common.properties.AppProperties;
 import com.thekey.stylekeyserver.oauth.entity.ProviderType;
 import com.thekey.stylekeyserver.oauth.entity.RoleType;
 import com.thekey.stylekeyserver.oauth.info.OAuth2UserInfo;

--- a/src/main/java/com/thekey/stylekeyserver/s3/S3ErrorMessage.java
+++ b/src/main/java/com/thekey/stylekeyserver/s3/S3ErrorMessage.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 public enum S3ErrorMessage {
     FILE_UPLOAD_FAILED("이미지 파일 업로드에 실패했습니다."),
     FILE_ALREADY_EXISTS("동일한 이름의 이미지 파일이 존재합니다."),
-    FAIL_IMAGE_DELETE("이미지 삭제에 실패했습니다.");
+    FAIL_IMAGE_DELETE("이미지 삭제에 실패했습니다."),
+    NO_FILE_ITEM_ID("아이템 ID에 해당하는 이미지가 없습니다. item id : ");
 
     private String message;
 


### PR DESCRIPTION
### 관련 이슈
- #36
- #43 
- close #53 
- close #52 

### 작업 내용
* 일단 like 브랜치에서 이미지 파일 관련 리팩토링을 해서 죄송합니다. 😅 자잘한 에러가 많다보니 체크아웃을 못하고 한꺼번에 해결하게 되었네요..
* 코디룩을 좋아요 누르면 redis 메모리에 좋아요 한 코디룩 정보가 저장됩니다. 이때 그냥 코디룩 ID만 저장을 했었는데, 프론트 단에서 코디룩 정보 모두가 필요하다고 하여 그냥 DTO 자체를 저장하는 로직으로 변경했습니다.
* 좋아요를 누르면 좋아요 목록에 추가되며, 개수도 자동으로 증가합니다. 좋아요 취소 시 개수도 함께 감소합니다.
* 유저 정보는 일단 시큐리티 이슈로 Controller를 통해서가 아닌 @Bean을 사용하여 가져왔습니다.
* @rla124 수빈님께서 해당 부분 처리해주시면 다시 시도해보겠습니다.

### 변경 사항
* Image 객체를 생성하여 각각 필요한 Item, Brand, CoordinateLook 객체에 매핑하였습니다. 이에 따라 각각의 엔티티와 DTO 코드를 모두 리팩토링하는 작업이 이루어졌습니다.
* yml 파일의 profile 설정을 `dev`로 변경하여 개발 환경과 운영 환경을 분리했습니다. 이는 이미지 삭제 로직이 현재 배치 방식으로 구현 되었었는데, 실제 개발할 때는 계속해서 데이터를 삽입하고, 삭제를 테스트해봐야 하는 이유로 즉시 삭제를 `dev` 단에서 실행되도록 추가 구현 하였습니다. 또한, 배치 방식은 `prod` 단에서 실행되도록 설정했습니다.
* 현재 프로젝트의 패키지가 조금 난잡한 것 같아서 수정했습니다. 
[s3, security, properties, exception 관련 클래스 common 패키지로 이동](https://github.com/styleKey/back/commit/63c31ba67197319f650336a8504447fab5db5c44)

### 수정 계획
* 현재 Controller 단에서 발생하는 예외 처리가 제대로 안 되어 있습니다. 제가 전역 에러 처리에 능숙하지 못하여 각각의 상황에 맞는 에러 처리를 하지 못한 것 같습니다. 🥲 
* @JWbase 정우님께서 에러 처리 로직 리팩토링 해주신다면 저도 반영하여 해당 부분 수정하겠습니다!