### PR TITLE
Refact: Security에서 SecurityContextHolder -> @AuthenticationPrincipal로 로그인 유저 정보 가져올 수 있도록 변경

### DIFF
--- a/src/main/java/com/thekey/stylekeyserver/auth/controller/UserController.java
+++ b/src/main/java/com/thekey/stylekeyserver/auth/controller/UserController.java
@@ -1,6 +1,8 @@
 package com.thekey.stylekeyserver.auth.controller;
 
+import com.thekey.stylekeyserver.oauth.entity.UserPrincipal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,18 +14,14 @@ import com.thekey.stylekeyserver.common.exception.ApiResponse;
 
 
 @RestController
-@RequestMapping("/api/v1/users")
+@RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
 
     private final UserService userService;
-
     @GetMapping
-    public ApiResponse getUser() {
-        org.springframework.security.core.userdetails.User principal = (org.springframework.security.core.userdetails.User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-
-        User user = userService.getUser(principal.getUsername());
-
-        return ApiResponse.success(user);
+    public ApiResponse getUser(@AuthenticationPrincipal UserPrincipal user) {
+        User userDetails = userService.getUser(user.getUsername());
+        return ApiResponse.success(userDetails);
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/common/security/JwtConfig.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/security/JwtConfig.java
@@ -1,10 +1,15 @@
 package com.thekey.stylekeyserver.common.security;
 
+import com.thekey.stylekeyserver.auth.repository.UserRepository;
+import com.thekey.stylekeyserver.oauth.service.CustomUserDetailsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.thekey.stylekeyserver.oauth.token.AuthTokenProvider;
+import org.springframework.context.annotation.Primary;
 
 
 @Configuration
@@ -12,8 +17,18 @@ public class JwtConfig {
     @Value("${jwt.secret}")
     private String secret;
 
-    @Bean
-    public AuthTokenProvider jwtProvider() {
-        return new AuthTokenProvider(secret);
+    @Autowired
+    private UserRepository userRepository;
+
+    @Bean("jwtCustomUserDetailsService")
+    @Primary
+    public CustomUserDetailsService customUserDetailsService() {
+        return new CustomUserDetailsService(userRepository);
     }
+
+    @Bean
+    public AuthTokenProvider jwtProvider(@Qualifier("jwtCustomUserDetailsService") CustomUserDetailsService customUserDetailsService) {
+        return new AuthTokenProvider(secret, customUserDetailsService);
+    }
+
 }

--- a/src/main/java/com/thekey/stylekeyserver/common/security/SecurityConfig.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/security/SecurityConfig.java
@@ -136,8 +136,11 @@ public class SecurityConfig {
         http.authorizeRequests()
                 .requestMatchers("/swagger-ui/**").permitAll()
                 .requestMatchers("/v3/api-docs/**").permitAll()
-                .requestMatchers("/api/*").permitAll()
-                .requestMatchers("/admin/*").permitAll()
+                .requestMatchers("/api/test-questions").permitAll()
+//                .requestMatchers("/admin/**").permitAll()
+                .requestMatchers("/api/test").authenticated()
+                .requestMatchers("/api/users").authenticated()
+                .requestMatchers("/api/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
 


### PR DESCRIPTION
기존 Spring Security 상에서 로그인 유저 정보를 가지고 올 때 
`SecurityContextHolder.getContext().getAuthentication().getPrincipal()`
위 방법으로 가져 왔으나 
`@AuthenticationPrincipal UserPrincipal user` 시큐리티 어노테이션을 통해서 유저 정보 가져올 수 있도록
Spring Security 부분을 수정 완료하였습니다.
postman으로 로그인 마이페이지에 사용될 로그인 유저 정보를 가지고 오는 api/users를 연결했을 때
정상적으로  200ok를 확인하였습니다.

아래 PR  및 디스코드에서 언급해주신 부분에 대한 이슈 해결 PR 입니다.
https://github.com/styleKey/back/pull/54

close #59 