### PR TITLE
Feat/#61 공용 컴포넌트 및 예외 처리 

### DIFF
--- a/src/main/java/com/thekey/stylekeyserver/common/dto/CreateResponse.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/dto/CreateResponse.java
@@ -1,0 +1,21 @@
+package com.thekey.stylekeyserver.common.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CreateResponse {
+
+    private long id;
+
+    private CreateResponse(long id) {
+        this.id = id;
+    }
+
+    public static CreateResponse of(long id) {
+        return new CreateResponse(id);
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/common/exception/ApiException.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/exception/ApiException.java
@@ -1,0 +1,14 @@
+package com.thekey.stylekeyserver.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public ApiException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/exception/GlobalExceptionHandler.java
@@ -7,39 +7,70 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.nio.file.FileAlreadyExistsException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(IOException.class)
-    public ApiResponse handleIOException(IOException e) {
+    public ApiResponse<Object> handleIOException(IOException e) {
         return ApiResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INVALID_IMAGE_FORMAT.getMessage());
     }
 
     @ExceptionHandler(FileAlreadyExistsException.class)
-    public ApiResponse handleFileAlreadyExistsException(FileAlreadyExistsException e) {
+    public ApiResponse<Object> handleFileAlreadyExistsException(FileAlreadyExistsException e) {
         return ApiResponse.of(HttpStatus.BAD_REQUEST, S3ErrorMessage.FILE_ALREADY_EXISTS.getMessage());
     }
 
     @ExceptionHandler(AmazonServiceException.class)
-    public ApiResponse handleAmazonServiceException(Exception e) {
+    public ApiResponse<Object> handleAmazonServiceException(Exception e) {
         return ApiResponse.of(HttpStatus.SERVICE_UNAVAILABLE, ErrorCode.FILE_UPLOAD_FAILED.getMessage());
     }
 
     @ExceptionHandler({UnsupportedEncodingException.class, MalformedURLException.class})
-    public ApiResponse handleS3Exception(Exception e) {
+    public ApiResponse<Object> handleS3Exception(Exception e) {
         return ApiResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
     }
 
     @ExceptionHandler(RuntimeException.class)
-    public ApiResponse handleRuntimeException(RuntimeException e) {
+    public ApiResponse<Object> handleRuntimeException(RuntimeException e) {
         return ApiResponse.of(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getMessage());
     }
 
     @ExceptionHandler(Exception.class)
-    public ApiResponse handleException(Exception e) {
+    public ApiResponse<Object> handleException(Exception e) {
         return ApiResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ApiResponse<Object> handleHttpMessageNotReadableException() {
+        return ApiResponse.of(HttpStatus.BAD_REQUEST, "요청 하신 바디의 형태가 잘못 되었습니다.");
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ApiResponse<Object> handleMethodArgumentTypeMismatchException(
+        MethodArgumentTypeMismatchException exception) {
+        return ApiResponse.of(HttpStatus.BAD_REQUEST, "'%s'의 타입이 잘못되었습니다.",
+            exception.getParameter().getParameterName());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<Object> handleMethodArgumentNotValidException(
+        MethodArgumentNotValidException exception) {
+        FieldError fieldError = getFirstFieldError(exception);
+
+        return ApiResponse.of(HttpStatus.BAD_REQUEST,
+            String.format(String.format("[%s] %s", fieldError.getField(), fieldError.getDefaultMessage())));
+    }
+
+    private FieldError getFirstFieldError(MethodArgumentNotValidException exception) {
+        BindingResult bindingResult = exception.getBindingResult();
+        return bindingResult.getFieldErrors().get(0);
     }
 }


### PR DESCRIPTION
```java
public class ApiException extends RuntimeException {

    private final ErrorCode errorCode;

    public ApiException(ErrorCode errorCode) {
        super(errorCode.getMessage());
        this.errorCode = errorCode;
    }
}
```
- service 단에서 orElseThrow시 해당 에러를 통해 프론트 측에서 어떤 문제가 발생했는지 알 수 있도록 던져 줄 수 있는게 좋을 것 같습니다.

- 에러 원인을 확인할 수 있도록 exceptionHandler도 추가했습니다.

- 마지막으로 create시 즉 post요청 후 자원이 생성될 때 생성된 엔티티의 id정보만 넘기고 끝내게 되는데 해당 작업을 공통으로 할 수 있도록 common 패키지에 CreateResponse dto를 추가했습니다.