### PR TITLE
[Feat/#76] 테스트 결과 생성 저장 로직 리팩터링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,68 +1,69 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.1.7'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'org.springframework.boot' version '3.1.7'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'com.thekey'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
-	implementation 'org.springframework.boot:spring-boot-starter'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	 implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	testImplementation 'io.projectreactor:reactor-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 
-	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.1.0'
-	implementation group: 'io.swagger.core.v3', name: 'swagger-core-jakarta', version: '2.2.7'
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.1.0'
+    implementation group: 'io.swagger.core.v3', name: 'swagger-core-jakarta', version: '2.2.7'
 
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
-	/* Redis cache */
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	
-	compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
-	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
-	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+    /* Redis cache */
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-	implementation 'org.apache.commons:commons-lang3:3.12.0'
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 
-	// implementation 'org.slf4j:slf4j-api:1.7.32'
-	// implementation 'ch.qos.logback:logback-classic:1.2.6'
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
+
+    // implementation 'org.slf4j:slf4j-api:1.7.32'
+    // implementation 'ch.qos.logback:logback-classic:1.2.6'
 }
 
 tasks.named('bootBuildImage') {
-	builder = 'paketobuildpacks/builder-jammy-base:latest'
+    builder = 'paketobuildpacks/builder-jammy-base:latest'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/thekey/stylekeyserver/common/exception/ErrorCode.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/exception/ErrorCode.java
@@ -42,6 +42,9 @@ public enum ErrorCode {
     FILE_ALREADY_EXISTS(BAD_REQUEST, "이미 등록된 이미지입니다."),
     INVALID_IMAGE_FORMAT(BAD_REQUEST, "이미지 형식이 올바르지 않습니다."),
 
+    /* 스타일 포인트 관련 */
+    STYLE_POINT_NOT_FOUND(NOT_FOUND, "해당 스타일 포인트를 찾을 수 없습니다."),
+
     /* 테스트 관련 */
     TEST_RESULT_NOT_FOUND(NOT_FOUND, "테스트 결과를 찾을 수 없습니다."),
     TEST_ANSWER_NOT_FOUND(NOT_FOUND, "테스트 선택지를 찾을 수 없습니다."),

--- a/src/main/java/com/thekey/stylekeyserver/common/exception/ErrorCode.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/exception/ErrorCode.java
@@ -48,7 +48,9 @@ public enum ErrorCode {
     /* 테스트 관련 */
     TEST_RESULT_NOT_FOUND(NOT_FOUND, "테스트 결과를 찾을 수 없습니다."),
     TEST_ANSWER_NOT_FOUND(NOT_FOUND, "테스트 선택지를 찾을 수 없습니다."),
-    UNAUTHORIZED_TEST_RESULT(FORBIDDEN, "테스트 결과에 대한 권한이 없습니다.");
+    UNAUTHORIZED_TEST_RESULT(FORBIDDEN, "테스트 결과에 대한 권한이 없습니다."),
+    DUPLICATE_TEST_ANSWERS(BAD_REQUEST, "하나의 질문에는 하나의 답변만 할 수 있습니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/thekey/stylekeyserver/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/exception/GlobalExceptionHandler.java
@@ -38,9 +38,9 @@ public class GlobalExceptionHandler {
         return ApiResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.ERROR_INTERNAL_SERVER_ERROR.getMessage());
     }
 
-    @ExceptionHandler(RuntimeException.class)
-    public ApiResponse<Object> handleRuntimeException(RuntimeException e) {
-        return ApiResponse.of(HttpStatus.BAD_REQUEST, ErrorCode.ERROR_BAD_REQUEST.getMessage());
+    @ExceptionHandler(ApiException.class)
+    public ApiResponse<Object> handleApiException(ApiException e) {
+        return ApiResponse.of(HttpStatus.BAD_REQUEST, e.getMessage());
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/thekey/stylekeyserver/test/dto/request/SaveTestResultRequest.java
+++ b/src/main/java/com/thekey/stylekeyserver/test/dto/request/SaveTestResultRequest.java
@@ -1,0 +1,17 @@
+package com.thekey.stylekeyserver.test.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Map;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonNaming(SnakeCaseStrategy.class)
+public class SaveTestResultRequest {
+
+    private Map<Long, Integer> stylePoints;
+}

--- a/src/main/java/com/thekey/stylekeyserver/test/entity/TestAnswer.java
+++ b/src/main/java/com/thekey/stylekeyserver/test/entity/TestAnswer.java
@@ -1,12 +1,21 @@
 package com.thekey.stylekeyserver.test.entity;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import jakarta.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter

--- a/src/main/java/com/thekey/stylekeyserver/test/entity/TestResult.java
+++ b/src/main/java/com/thekey/stylekeyserver/test/entity/TestResult.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Table(name = "test_result")

--- a/src/main/java/com/thekey/stylekeyserver/test/repository/TestAnswerRepository.java
+++ b/src/main/java/com/thekey/stylekeyserver/test/repository/TestAnswerRepository.java
@@ -3,11 +3,13 @@ package com.thekey.stylekeyserver.test.repository;
 import com.thekey.stylekeyserver.test.entity.TestAnswer;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TestAnswerRepository extends JpaRepository<TestAnswer, Long> {
 
+    @Query("SELECT ta FROM TestAnswer ta JOIN FETCH ta.testAnswerDetails WHERE ta.id IN :ids")
     List<TestAnswer> findByIdIn(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/thekey/stylekeyserver/test/repository/TestResultRepository.java
+++ b/src/main/java/com/thekey/stylekeyserver/test/repository/TestResultRepository.java
@@ -4,12 +4,13 @@ import com.thekey.stylekeyserver.auth.entity.User;
 import com.thekey.stylekeyserver.test.entity.TestResult;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TestResultRepository extends JpaRepository<TestResult, Long> {
 
-    List<TestResult> findAllByUser(User user);
+    List<TestResult> findAllByUser(@Param("user") User user);
 
-    void deleteByUserAndId(User user, Long id);
+    void deleteByUserAndId(@Param("user") User user, @Param("id") Long id);
 }

--- a/src/main/java/com/thekey/stylekeyserver/test/service/TestResultService.java
+++ b/src/main/java/com/thekey/stylekeyserver/test/service/TestResultService.java
@@ -1,10 +1,10 @@
 package com.thekey.stylekeyserver.test.service;
 
-import static com.thekey.stylekeyserver.common.exception.ErrorCode.AUTHENTICATED_FAIL;
 import static com.thekey.stylekeyserver.common.exception.ErrorCode.DUPLICATE_TEST_ANSWERS;
 import static com.thekey.stylekeyserver.common.exception.ErrorCode.STYLE_POINT_NOT_FOUND;
 import static com.thekey.stylekeyserver.common.exception.ErrorCode.TEST_RESULT_NOT_FOUND;
 import static com.thekey.stylekeyserver.common.exception.ErrorCode.UNAUTHORIZED_TEST_RESULT;
+import static com.thekey.stylekeyserver.common.exception.ErrorCode.USER_NOT_FOUND;
 
 import com.thekey.stylekeyserver.auth.entity.User;
 import com.thekey.stylekeyserver.auth.repository.UserRepository;
@@ -89,7 +89,7 @@ public class TestResultService {
     private User findUser(String userId) {
         User findUser = userRepository.findByUserId(userId);
         if (findUser == null) {
-            throw new ApiException(AUTHENTICATED_FAIL);
+            throw new ApiException(USER_NOT_FOUND);
         }
         return findUser;
     }


### PR DESCRIPTION
## 👊🏻 작업 내용

- [X]  /api/tests 테스트 결과 저장 api 구현
- [X] /api/tests/preview 테스트 결과 생성 api 구현
- [X] 테스트 결과 요청 시 Validation이 작동안하는 오류 수정
- [X] 하나의 질문지에 하나의 정답만 제출 하도록 중복 검사 구현
- [X] ControllerAdvice가 ApiException 처리하도록 수정

## 🏌🏻 리뷰 포인트
비 로그인 / 로그인 시 로직이 다르기 때문에 하나의 api안에서 분기처리 후 해결하려고 했지만 고민 끝에 api를 분리하는게 좀 더 나은 설계라고 판단했습니다. 또한 @Validate 어노테이션이 동작하지 않아 확인해본 결과 3점대 버전부터는 스프링 의존성에 validation을 반드시 추가해야하는 걸 알게 되어서 추가 했습니다.

## 🧘🏻 기타 사항

close #76 