### PR TITLE
[feat/#78] refactor: TestAnswerDetail 엔티티 안에 있는 StylePoint 지연로딩 수정

### DIFF
--- a/src/main/java/com/thekey/stylekeyserver/test/repository/TestAnswerRepository.java
+++ b/src/main/java/com/thekey/stylekeyserver/test/repository/TestAnswerRepository.java
@@ -10,6 +10,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface TestAnswerRepository extends JpaRepository<TestAnswer, Long> {
 
-    @Query("SELECT ta FROM TestAnswer ta JOIN FETCH ta.testAnswerDetails WHERE ta.id IN :ids")
+    @Query("SELECT ta "
+        + "FROM TestAnswer ta "
+        + "JOIN FETCH ta.testAnswerDetails tad "
+        + "JOIN FETCH tad.stylePoint "
+        + "WHERE ta.id IN :ids")
     List<TestAnswer> findByIdIn(@Param("ids") List<Long> ids);
 }


### PR DESCRIPTION
## 👊🏻 작업 내용

- [X] findByIn 메서드 최적화

## 🏌🏻 리뷰 포인트
### 리팩토링 전 쿼리문을 보면 두개의 대표 스타일 포인트를 찾기 위해 두 번의 쿼리 문이 추가적으로 나가는 것을 볼 수 있습니다.
![image](https://github.com/styleKey/back/assets/87960006/f3dd4918-a5aa-4647-bf2c-a7973c18936e)
- 리팩토링 전

### 리팩토링 후 한번의 쿼리문으로 모든 값을 다 가져오는 것을 볼 수 있습니다.
<img width="493" alt="image" src="https://github.com/styleKey/back/assets/87960006/2770b53f-5b8a-4597-9086-d46e6cc33d9c">

- 리팩토링 후



## 🧘🏻 기타 사항

close #78