### PR TITLE
관리자페이지 페이징 처리 추가

### DIFF
--- a/src/main/java/com/thekey/stylekeyserver/brand/controller/BrandAdminController.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/controller/BrandAdminController.java
@@ -2,6 +2,7 @@ package com.thekey.stylekeyserver.brand.controller;
 
 import com.thekey.stylekeyserver.brand.domain.Brand;
 import com.thekey.stylekeyserver.brand.dto.request.BrandRequest;
+import com.thekey.stylekeyserver.brand.dto.response.BrandPageResponse;
 import com.thekey.stylekeyserver.brand.dto.response.BrandResponse;
 import com.thekey.stylekeyserver.brand.service.BrandAdminService;
 import com.thekey.stylekeyserver.common.exception.ApiResponse;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -53,13 +55,9 @@ public class BrandAdminController {
 
     @GetMapping
     @Operation(summary = "Read All Brands", description = "브랜드 정보 전체 조회")
-    public ApiResponse<List<BrandResponse>> getBrands() {
-        List<Brand> brands = brandAdminService.findAll();
-        List<BrandResponse> response = brands.stream()
-                .map(BrandResponse::of)
-                .collect(Collectors.toList());
-
-        return ApiResponse.ok(response);
+    public ApiResponse<BrandPageResponse> getBrands(@RequestParam(value = "pageNo", defaultValue = "0") int pageNo,
+                                                    @RequestParam(value = "pageSize", defaultValue = "10") int pageSize) {
+        return ApiResponse.ok(brandAdminService.findAllPaging(pageNo, pageSize));
     }
 
     @GetMapping("style-points/{id}")

--- a/src/main/java/com/thekey/stylekeyserver/brand/controller/BrandAdminController.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/controller/BrandAdminController.java
@@ -14,6 +14,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,7 +24,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -55,9 +57,9 @@ public class BrandAdminController {
 
     @GetMapping
     @Operation(summary = "Read All Brands", description = "브랜드 정보 전체 조회")
-    public ApiResponse<BrandPageResponse> getBrands(@RequestParam(value = "pageNo", defaultValue = "0") int pageNo,
-                                                    @RequestParam(value = "pageSize", defaultValue = "10") int pageSize) {
-        return ApiResponse.ok(brandAdminService.findAllPaging(pageNo, pageSize));
+    public ApiResponse<BrandPageResponse> getBrands(
+            @PageableDefault(sort = "id", direction = Direction.DESC) Pageable pageable) {
+        return ApiResponse.ok(brandAdminService.findAllPaging(pageable));
     }
 
     @GetMapping("style-points/{id}")

--- a/src/main/java/com/thekey/stylekeyserver/brand/dto/response/BrandPageResponse.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/dto/response/BrandPageResponse.java
@@ -1,0 +1,44 @@
+package com.thekey.stylekeyserver.brand.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@JsonNaming(SnakeCaseStrategy.class)
+public class BrandPageResponse {
+
+    private List<BrandResponse> content;
+    private int pageNo;
+    private int pageSize;
+    private long totalElements;
+    private int totalPages;
+    private boolean last;
+
+    @Builder
+    private BrandPageResponse(List<BrandResponse> content, int pageNo, int pageSize, long totalElements, int totalPages,
+                             boolean last) {
+        this.content = content;
+        this.pageNo = pageNo;
+        this.pageSize = pageSize;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.last = last;
+    }
+
+    public static BrandPageResponse of(List<BrandResponse> content, int pageNo, int pageSize, long totalElements, int totalPages,
+                              boolean last) {
+        return BrandPageResponse.builder()
+                .content(content)
+                .pageNo(pageNo)
+                .pageSize(pageSize)
+                .totalElements(totalElements)
+                .totalPages(totalPages)
+                .last(last)
+                .build();
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/brand/dto/response/BrandPageResponse.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/dto/response/BrandPageResponse.java
@@ -2,10 +2,12 @@ package com.thekey.stylekeyserver.brand.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.thekey.stylekeyserver.brand.domain.Brand;
 import java.util.List;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
 
 @Data
 @NoArgsConstructor
@@ -30,15 +32,14 @@ public class BrandPageResponse {
         this.last = last;
     }
 
-    public static BrandPageResponse of(List<BrandResponse> content, int pageNo, int pageSize, long totalElements, int totalPages,
-                              boolean last) {
+    public static BrandPageResponse of(List<BrandResponse> content, Page<Brand> brandPage) {
         return BrandPageResponse.builder()
                 .content(content)
-                .pageNo(pageNo)
-                .pageSize(pageSize)
-                .totalElements(totalElements)
-                .totalPages(totalPages)
-                .last(last)
+                .pageNo(brandPage.getNumber())
+                .pageSize(brandPage.getSize())
+                .totalElements(brandPage.getTotalElements())
+                .totalPages(brandPage.getTotalPages())
+                .last(brandPage.isLast())
                 .build();
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminService.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminService.java
@@ -2,6 +2,7 @@ package com.thekey.stylekeyserver.brand.service;
 
 import com.thekey.stylekeyserver.brand.domain.Brand;
 import com.thekey.stylekeyserver.brand.dto.request.BrandRequest;
+import com.thekey.stylekeyserver.brand.dto.response.BrandPageResponse;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -12,6 +13,8 @@ public interface BrandAdminService {
     Brand findById(Long id);
 
     List<Brand> findAll();
+
+    BrandPageResponse findAllPaging(int pageNo, int pageSize);
 
     List<Brand> findByStylePointId(Long id);
 

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminService.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminService.java
@@ -4,6 +4,7 @@ import com.thekey.stylekeyserver.brand.domain.Brand;
 import com.thekey.stylekeyserver.brand.dto.request.BrandRequest;
 import com.thekey.stylekeyserver.brand.dto.response.BrandPageResponse;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface BrandAdminService {
@@ -14,7 +15,7 @@ public interface BrandAdminService {
 
     List<Brand> findAll();
 
-    BrandPageResponse findAllPaging(int pageNo, int pageSize);
+    BrandPageResponse findAllPaging(Pageable pageable);
 
     List<Brand> findByStylePointId(Long id);
 

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
@@ -38,7 +38,7 @@ public class BrandAdminServiceImpl implements BrandAdminService {
     @Override
     @Transactional
     public Brand create(BrandRequest requestDto, MultipartFile brandImageFile) {
-        validationImageFile(brandImageFile);
+        validateImageFile(brandImageFile);
 
         Image image = s3Service.uploadFile(brandImageFile, Type.BRAND);
         imageRepository.save(image);
@@ -128,7 +128,7 @@ public class BrandAdminServiceImpl implements BrandAdminService {
         brandRepository.deleteById(id);
     }
 
-    private void validationImageFile(MultipartFile brandImageFile) {
+    private void validateImageFile(MultipartFile brandImageFile) {
         if (brandImageFile == null || brandImageFile.isEmpty()) {
             throw new ApiException(ErrorCode.FILE_NOT_FOUND);
         }

--- a/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/brand/service/BrandAdminServiceImpl.java
@@ -18,9 +18,7 @@ import com.thekey.stylekeyserver.stylepoint.domain.StylePoint;
 import com.thekey.stylekeyserver.stylepoint.service.StylePointAdminService;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -66,16 +64,13 @@ public class BrandAdminServiceImpl implements BrandAdminService {
 
     @Override
     @Transactional(readOnly = true)
-    public BrandPageResponse findAllPaging(int pageNo, int pageSize) {
-        // 페이지 넘버는 1부터 시작하도록 조정
-        Pageable pageable = PageRequest.of(pageNo - 1, pageSize, Sort.by("id").descending());
+    public BrandPageResponse findAllPaging(Pageable pageable) {
         Page<Brand> brandPage = brandRepository.findAll(pageable);
 
         List<BrandResponse> brandResponses = brandPage.getContent().stream()
                 .map(BrandResponse::of)
                 .toList();
-        return BrandPageResponse.of(brandResponses, pageNo, pageSize, brandPage.getTotalElements(),
-                brandPage.getTotalPages(), brandPage.isLast());
+        return BrandPageResponse.of(brandResponses, brandPage);
     }
 
     @Override

--- a/src/main/java/com/thekey/stylekeyserver/coordinatelook/controller/CoordinateLookAdminController.java
+++ b/src/main/java/com/thekey/stylekeyserver/coordinatelook/controller/CoordinateLookAdminController.java
@@ -1,10 +1,10 @@
 package com.thekey.stylekeyserver.coordinatelook.controller;
 
-import com.thekey.stylekeyserver.common.exception.ApiException;
 import com.thekey.stylekeyserver.common.exception.ApiResponse;
 import com.thekey.stylekeyserver.common.exception.ErrorCode;
 import com.thekey.stylekeyserver.coordinatelook.domain.CoordinateLook;
 import com.thekey.stylekeyserver.coordinatelook.dto.response.CoordinateLookDetailsResponse;
+import com.thekey.stylekeyserver.coordinatelook.dto.response.CoordinateLookPageResponse;
 import com.thekey.stylekeyserver.coordinatelook.dto.response.CoordinateLookResponse;
 import com.thekey.stylekeyserver.coordinatelook.dto.request.CoordinateLookRequest;
 import com.thekey.stylekeyserver.coordinatelook.service.CoordinateLookAdminService;
@@ -20,13 +20,13 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -67,13 +67,10 @@ public class CoordinateLookAdminController {
 
     @GetMapping
     @Operation(summary = "Read All CoordinateLook", description = "코디룩 정보 전체 조회")
-    public ApiResponse<List<CoordinateLookResponse>> getCoordinateLooks() {
-        List<CoordinateLook> coordinateLooks = coordinateLookAdminService.findAll();
-        List<CoordinateLookResponse> response = coordinateLooks.stream()
-                .map(CoordinateLookResponse::of)
-                .collect(Collectors.toList());
-
-        return ApiResponse.ok(response);
+    public ApiResponse<CoordinateLookPageResponse> getCoordinateLooks(
+            @RequestParam(value = "pageNo", defaultValue = "0") int pageNo,
+            @RequestParam(value = "pageSize", defaultValue = "10") int pageSize) {
+        return ApiResponse.ok(coordinateLookAdminService.findAllPaging(pageNo, pageSize));
     }
 
     @GetMapping("/style-points/{id}")
@@ -89,7 +86,8 @@ public class CoordinateLookAdminController {
 
     @PutMapping("/{id}")
     @Operation(summary = "Update CoordinateLook", description = "코디룩 정보 수정")
-    public ApiResponse<Void> update(@PathVariable Long id, @RequestPart(required = false) CoordinateLookRequest requestDto,
+    public ApiResponse<Void> update(@PathVariable Long id,
+                                    @RequestPart(required = false) CoordinateLookRequest requestDto,
                                     @RequestPart(value = "coordinate_looks_imageFile", required = false) MultipartFile coordinateLookImageFile) {
         coordinateLookAdminService.update(id, requestDto, coordinateLookImageFile);
         return ApiResponse.ok();

--- a/src/main/java/com/thekey/stylekeyserver/coordinatelook/controller/CoordinateLookAdminController.java
+++ b/src/main/java/com/thekey/stylekeyserver/coordinatelook/controller/CoordinateLookAdminController.java
@@ -19,6 +19,9 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,7 +29,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -68,9 +70,8 @@ public class CoordinateLookAdminController {
     @GetMapping
     @Operation(summary = "Read All CoordinateLook", description = "코디룩 정보 전체 조회")
     public ApiResponse<CoordinateLookPageResponse> getCoordinateLooks(
-            @RequestParam(value = "pageNo", defaultValue = "0") int pageNo,
-            @RequestParam(value = "pageSize", defaultValue = "10") int pageSize) {
-        return ApiResponse.ok(coordinateLookAdminService.findAllPaging(pageNo, pageSize));
+            @PageableDefault(sort = "id", direction = Direction.DESC) Pageable pageable) {
+        return ApiResponse.ok(coordinateLookAdminService.findAllPaging(pageable));
     }
 
     @GetMapping("/style-points/{id}")

--- a/src/main/java/com/thekey/stylekeyserver/coordinatelook/dto/response/CoordinateLookPageResponse.java
+++ b/src/main/java/com/thekey/stylekeyserver/coordinatelook/dto/response/CoordinateLookPageResponse.java
@@ -1,0 +1,46 @@
+package com.thekey.stylekeyserver.coordinatelook.dto.response;
+
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@JsonNaming(SnakeCaseStrategy.class)
+public class CoordinateLookPageResponse {
+
+    private List<CoordinateLookResponse> content;
+    private int pageNo;
+    private int pageSize;
+    private long totalElements;
+    private int totalPages;
+    private boolean last;
+
+    @Builder
+    private CoordinateLookPageResponse(List<CoordinateLookResponse> content, int pageNo, int pageSize,
+                                       long totalElements,
+                                       int totalPages, boolean last) {
+        this.content = content;
+        this.pageNo = pageNo;
+        this.pageSize = pageSize;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.last = last;
+    }
+
+    public static CoordinateLookPageResponse of(List<CoordinateLookResponse> content, int pageNo, int pageSize,
+                                                long totalElements, int totalPages, boolean last) {
+        return CoordinateLookPageResponse.builder()
+                .content(content)
+                .pageNo(pageNo)
+                .pageSize(pageSize)
+                .totalElements(totalElements)
+                .totalPages(totalPages)
+                .last(last)
+                .build();
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/coordinatelook/dto/response/CoordinateLookPageResponse.java
+++ b/src/main/java/com/thekey/stylekeyserver/coordinatelook/dto/response/CoordinateLookPageResponse.java
@@ -1,12 +1,13 @@
 package com.thekey.stylekeyserver.coordinatelook.dto.response;
 
-
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.thekey.stylekeyserver.coordinatelook.domain.CoordinateLook;
 import java.util.List;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
 
 @Data
 @NoArgsConstructor
@@ -32,15 +33,14 @@ public class CoordinateLookPageResponse {
         this.last = last;
     }
 
-    public static CoordinateLookPageResponse of(List<CoordinateLookResponse> content, int pageNo, int pageSize,
-                                                long totalElements, int totalPages, boolean last) {
+    public static CoordinateLookPageResponse of(List<CoordinateLookResponse> content, Page<CoordinateLook> coordinateLookPage) {
         return CoordinateLookPageResponse.builder()
                 .content(content)
-                .pageNo(pageNo)
-                .pageSize(pageSize)
-                .totalElements(totalElements)
-                .totalPages(totalPages)
-                .last(last)
+                .pageNo(coordinateLookPage.getNumber())
+                .pageSize(coordinateLookPage.getSize())
+                .totalElements(coordinateLookPage.getTotalElements())
+                .totalPages(coordinateLookPage.getTotalPages())
+                .last(coordinateLookPage.isLast())
                 .build();
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/coordinatelook/service/CoordinateLookAdminService.java
+++ b/src/main/java/com/thekey/stylekeyserver/coordinatelook/service/CoordinateLookAdminService.java
@@ -2,6 +2,7 @@ package com.thekey.stylekeyserver.coordinatelook.service;
 
 import com.thekey.stylekeyserver.coordinatelook.domain.CoordinateLook;
 import com.thekey.stylekeyserver.coordinatelook.dto.request.CoordinateLookRequest;
+import com.thekey.stylekeyserver.coordinatelook.dto.response.CoordinateLookPageResponse;
 import com.thekey.stylekeyserver.item.dto.request.ItemRequest;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
@@ -15,6 +16,7 @@ public interface CoordinateLookAdminService {
     CoordinateLook findById(Long id);
 
     List<CoordinateLook> findAll();
+    CoordinateLookPageResponse findAllPaging(int pageNo, int pageSize);
 
     List<CoordinateLook> findByStylePointId(Long id);
 

--- a/src/main/java/com/thekey/stylekeyserver/coordinatelook/service/CoordinateLookAdminService.java
+++ b/src/main/java/com/thekey/stylekeyserver/coordinatelook/service/CoordinateLookAdminService.java
@@ -5,6 +5,7 @@ import com.thekey.stylekeyserver.coordinatelook.dto.request.CoordinateLookReques
 import com.thekey.stylekeyserver.coordinatelook.dto.response.CoordinateLookPageResponse;
 import com.thekey.stylekeyserver.item.dto.request.ItemRequest;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface CoordinateLookAdminService {
@@ -16,7 +17,7 @@ public interface CoordinateLookAdminService {
     CoordinateLook findById(Long id);
 
     List<CoordinateLook> findAll();
-    CoordinateLookPageResponse findAllPaging(int pageNo, int pageSize);
+    CoordinateLookPageResponse findAllPaging(Pageable pageable);
 
     List<CoordinateLook> findByStylePointId(Long id);
 

--- a/src/main/java/com/thekey/stylekeyserver/coordinatelook/service/CoordinateLookAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/coordinatelook/service/CoordinateLookAdminServiceImpl.java
@@ -6,6 +6,8 @@ import com.thekey.stylekeyserver.common.exception.ApiException;
 import com.thekey.stylekeyserver.common.exception.ErrorCode;
 import com.thekey.stylekeyserver.coordinatelook.domain.CoordinateLook;
 import com.thekey.stylekeyserver.coordinatelook.dto.request.CoordinateLookRequest;
+import com.thekey.stylekeyserver.coordinatelook.dto.response.CoordinateLookPageResponse;
+import com.thekey.stylekeyserver.coordinatelook.dto.response.CoordinateLookResponse;
 import com.thekey.stylekeyserver.coordinatelook.repository.CoordinateLookRepository;
 import com.thekey.stylekeyserver.image.domain.Image;
 import com.thekey.stylekeyserver.image.domain.Type;
@@ -26,6 +28,10 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -98,6 +104,20 @@ public class CoordinateLookAdminServiceImpl implements CoordinateLookAdminServic
     @Transactional(readOnly = true)
     public List<CoordinateLook> findAll() {
         return coordinateLookRepository.findAll();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CoordinateLookPageResponse findAllPaging(int pageNo, int pageSize) {
+        // 페이지 넘버는 1부터 시작하도록 조정
+        Pageable pageable = PageRequest.of(pageNo - 1, pageSize, Sort.by("id").descending());
+        Page<CoordinateLook> itemPage = coordinateLookRepository.findAll(pageable);
+
+        List<CoordinateLookResponse> coordinateLookResponses = itemPage.getContent().stream()
+                .map(CoordinateLookResponse::of)
+                .toList();
+        return CoordinateLookPageResponse.of(coordinateLookResponses, pageNo, pageSize, itemPage.getTotalElements(),
+                itemPage.getTotalPages(), itemPage.isLast());
     }
 
     @Override

--- a/src/main/java/com/thekey/stylekeyserver/coordinatelook/service/CoordinateLookAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/coordinatelook/service/CoordinateLookAdminServiceImpl.java
@@ -29,9 +29,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -108,16 +106,13 @@ public class CoordinateLookAdminServiceImpl implements CoordinateLookAdminServic
 
     @Override
     @Transactional(readOnly = true)
-    public CoordinateLookPageResponse findAllPaging(int pageNo, int pageSize) {
-        // 페이지 넘버는 1부터 시작하도록 조정
-        Pageable pageable = PageRequest.of(pageNo - 1, pageSize, Sort.by("id").descending());
-        Page<CoordinateLook> itemPage = coordinateLookRepository.findAll(pageable);
+    public CoordinateLookPageResponse findAllPaging(Pageable pageable) {
+        Page<CoordinateLook> coordinateLookPage = coordinateLookRepository.findAll(pageable);
 
-        List<CoordinateLookResponse> coordinateLookResponses = itemPage.getContent().stream()
+        List<CoordinateLookResponse> coordinateLookResponses = coordinateLookPage.getContent().stream()
                 .map(CoordinateLookResponse::of)
                 .toList();
-        return CoordinateLookPageResponse.of(coordinateLookResponses, pageNo, pageSize, itemPage.getTotalElements(),
-                itemPage.getTotalPages(), itemPage.isLast());
+        return CoordinateLookPageResponse.of(coordinateLookResponses, coordinateLookPage);
     }
 
     @Override

--- a/src/main/java/com/thekey/stylekeyserver/item/controller/ItemAdminController.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/controller/ItemAdminController.java
@@ -2,21 +2,20 @@ package com.thekey.stylekeyserver.item.controller;
 
 import com.thekey.stylekeyserver.common.exception.ApiResponse;
 import com.thekey.stylekeyserver.common.exception.ErrorCode;
-import com.thekey.stylekeyserver.coordinatelook.service.CoordinateLookAdminService;
 import com.thekey.stylekeyserver.item.domain.Item;
+import com.thekey.stylekeyserver.item.dto.response.ItemPageResponse;
 import com.thekey.stylekeyserver.item.dto.response.ItemResponse;
 import com.thekey.stylekeyserver.item.service.ItemAdminService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Item", description = "Item API")
@@ -45,23 +44,16 @@ public class ItemAdminController {
 
     @GetMapping
     @Operation(summary = "Read All Items", description = "아이템 정보 전체 조회")
-    public ApiResponse<List<ItemResponse>> getItems() {
-        List<Item> items = itemAdminService.findAll();
-        List<ItemResponse> responses = items.stream()
-                .map(ItemResponse::of)
-                .collect(Collectors.toList());
-
-        return ApiResponse.ok(responses);
+    public ApiResponse<ItemPageResponse> getItems(@RequestParam(value = "pageNo", defaultValue = "0") int pageNo,
+                                                  @RequestParam(value = "pageSize", defaultValue = "10") int pageSize) {
+        return ApiResponse.ok(itemAdminService.findAllPaging(pageNo, pageSize));
     }
 
     @GetMapping("/coordinate-looks/{id}")
     @Operation(summary = "Read All Items By CoordinateLookId", description = "코디룩 ID에 해당하는 아이템 목록 전체 조회")
-    public ApiResponse<List<ItemResponse>> getItemsByCoordinateLookId(@PathVariable Long id) {
-        List<Item> items = itemAdminService.findAllByCoordinateLookId(id);
-        List<ItemResponse> responses = items.stream()
-                .map(ItemResponse::of)
-                .toList();
-
-        return ApiResponse.ok(responses);
+    public ApiResponse<ItemPageResponse> getItemsByCoordinateLookId(@PathVariable Long id,
+                                                                      @RequestParam(value = "pageNo", defaultValue = "0") int pageNo,
+                                                                      @RequestParam(value = "pageSize", defaultValue = "10") int pageSize) {
+        return ApiResponse.ok(itemAdminService.findAllByCoordinateLookId(id, pageNo, pageSize));
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/item/controller/ItemAdminController.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/controller/ItemAdminController.java
@@ -11,11 +11,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Item", description = "Item API")
@@ -44,16 +46,15 @@ public class ItemAdminController {
 
     @GetMapping
     @Operation(summary = "Read All Items", description = "아이템 정보 전체 조회")
-    public ApiResponse<ItemPageResponse> getItems(@RequestParam(value = "pageNo", defaultValue = "0") int pageNo,
-                                                  @RequestParam(value = "pageSize", defaultValue = "10") int pageSize) {
-        return ApiResponse.ok(itemAdminService.findAllPaging(pageNo, pageSize));
+    public ApiResponse<ItemPageResponse> getItems(
+            @PageableDefault(sort = "id", direction = Direction.DESC) Pageable pageable) {
+        return ApiResponse.ok(itemAdminService.findAllPaging(pageable));
     }
 
     @GetMapping("/coordinate-looks/{id}")
     @Operation(summary = "Read All Items By CoordinateLookId", description = "코디룩 ID에 해당하는 아이템 목록 전체 조회")
     public ApiResponse<ItemPageResponse> getItemsByCoordinateLookId(@PathVariable Long id,
-                                                                      @RequestParam(value = "pageNo", defaultValue = "0") int pageNo,
-                                                                      @RequestParam(value = "pageSize", defaultValue = "10") int pageSize) {
-        return ApiResponse.ok(itemAdminService.findAllByCoordinateLookId(id, pageNo, pageSize));
+                                                                    @PageableDefault(sort = "id", direction = Direction.DESC) Pageable pageable) {
+        return ApiResponse.ok(itemAdminService.findAllByCoordinateLookId(id, pageable));
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/item/dto/response/ItemPageResponse.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/dto/response/ItemPageResponse.java
@@ -2,10 +2,12 @@ package com.thekey.stylekeyserver.item.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.thekey.stylekeyserver.item.domain.Item;
 import java.util.List;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
 
 @Data
 @NoArgsConstructor
@@ -30,15 +32,14 @@ public class ItemPageResponse {
         this.last = last;
     }
 
-    public static ItemPageResponse of(List<ItemResponse> content, int pageNo, int pageSize, long totalElements, int totalPages,
-                                      boolean last) {
+    public static ItemPageResponse of(List<ItemResponse> content, Page<Item> itemPage) {
         return ItemPageResponse.builder()
                 .content(content)
-                .pageNo(pageNo)
-                .pageSize(pageSize)
-                .totalElements(totalElements)
-                .totalPages(totalPages)
-                .last(last)
+                .pageNo(itemPage.getNumber())
+                .pageSize(itemPage.getSize())
+                .totalElements(itemPage.getTotalElements())
+                .totalPages(itemPage.getTotalPages())
+                .last(itemPage.isLast())
                 .build();
     }
 }

--- a/src/main/java/com/thekey/stylekeyserver/item/dto/response/ItemPageResponse.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/dto/response/ItemPageResponse.java
@@ -1,0 +1,44 @@
+package com.thekey.stylekeyserver.item.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@JsonNaming(SnakeCaseStrategy.class)
+public class ItemPageResponse {
+
+    private List<ItemResponse> content;
+    private int pageNo;
+    private int pageSize;
+    private long totalElements;
+    private int totalPages;
+    private boolean last;
+
+    @Builder
+    private ItemPageResponse(List<ItemResponse> content, int pageNo, int pageSize, long totalElements, int totalPages,
+                             boolean last) {
+        this.content = content;
+        this.pageNo = pageNo;
+        this.pageSize = pageSize;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.last = last;
+    }
+
+    public static ItemPageResponse of(List<ItemResponse> content, int pageNo, int pageSize, long totalElements, int totalPages,
+                                      boolean last) {
+        return ItemPageResponse.builder()
+                .content(content)
+                .pageNo(pageNo)
+                .pageSize(pageSize)
+                .totalElements(totalElements)
+                .totalPages(totalPages)
+                .last(last)
+                .build();
+    }
+}

--- a/src/main/java/com/thekey/stylekeyserver/item/repository/ItemRepository.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/repository/ItemRepository.java
@@ -3,10 +3,13 @@ package com.thekey.stylekeyserver.item.repository;
 import com.thekey.stylekeyserver.coordinatelook.domain.CoordinateLook;
 import com.thekey.stylekeyserver.item.domain.Item;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
 
+    Page<Item> findItemByCoordinateLook(CoordinateLook coordinateLook, Pageable pageable);
     List<Item> findItemByCoordinateLook(CoordinateLook coordinateLook);
     boolean existsByCoordinateLookId(Long coordinateLookId);
 }

--- a/src/main/java/com/thekey/stylekeyserver/item/service/ItemAdminService.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/service/ItemAdminService.java
@@ -4,6 +4,7 @@ import com.thekey.stylekeyserver.item.domain.Item;
 import com.thekey.stylekeyserver.item.dto.request.ItemRequest;
 import com.thekey.stylekeyserver.item.dto.response.ItemPageResponse;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface ItemAdminService {
@@ -14,10 +15,10 @@ public interface ItemAdminService {
 
     List<Item> findAll();
 
-    ItemPageResponse findAllPaging(int pageNo, int pageSize);
+    ItemPageResponse findAllPaging(Pageable pageable);
 
     List<Item> findAllByCoordinateLookId(Long id);
-    ItemPageResponse findAllByCoordinateLookId(Long coordinateLookId, int pageNo, int pageSize);
+    ItemPageResponse findAllByCoordinateLookId(Long coordinateLookId, Pageable pageable);
 
     Item update(Long coordinateLookId, Long itemId, ItemRequest requestDto, MultipartFile imageFile);
 

--- a/src/main/java/com/thekey/stylekeyserver/item/service/ItemAdminService.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/service/ItemAdminService.java
@@ -2,6 +2,7 @@ package com.thekey.stylekeyserver.item.service;
 
 import com.thekey.stylekeyserver.item.domain.Item;
 import com.thekey.stylekeyserver.item.dto.request.ItemRequest;
+import com.thekey.stylekeyserver.item.dto.response.ItemPageResponse;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -12,7 +13,11 @@ public interface ItemAdminService {
     Item findById(Long id);
 
     List<Item> findAll();
+
+    ItemPageResponse findAllPaging(int pageNo, int pageSize);
+
     List<Item> findAllByCoordinateLookId(Long id);
+    ItemPageResponse findAllByCoordinateLookId(Long coordinateLookId, int pageNo, int pageSize);
 
     Item update(Long coordinateLookId, Long itemId, ItemRequest requestDto, MultipartFile imageFile);
 

--- a/src/main/java/com/thekey/stylekeyserver/item/service/ItemAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/service/ItemAdminServiceImpl.java
@@ -25,9 +25,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -78,12 +76,9 @@ public class ItemAdminServiceImpl implements ItemAdminService {
 
     @Override
     @Transactional(readOnly = true)
-    public ItemPageResponse findAllPaging(int pageNo, int pageSize) {
-        // 페이지 넘버는 1부터 시작하도록 조정
-        Pageable pageable = PageRequest.of(pageNo - 1, pageSize, Sort.by("id").descending());
+    public ItemPageResponse findAllPaging(Pageable pageable) {
         Page<Item> itemPage = itemRepository.findAll(pageable);
-
-        return createItemPageResponse(itemPage, pageNo, pageSize);
+        return createItemPageResponse(itemPage);
     }
 
     @Override
@@ -95,12 +90,11 @@ public class ItemAdminServiceImpl implements ItemAdminService {
 
     @Override
     @Transactional(readOnly = true)
-    public ItemPageResponse findAllByCoordinateLookId(Long coordinateLookId, int pageNo, int pageSize) {
-        Pageable pageable = PageRequest.of(pageNo - 1, pageSize, Sort.by("id").descending());
+    public ItemPageResponse findAllByCoordinateLookId(Long coordinateLookId, Pageable pageable) {
         CoordinateLook coordinateLook = coordinateLookAdminService.findById(coordinateLookId);
         Page<Item> itemPage = itemRepository.findItemByCoordinateLook(coordinateLook, pageable);
 
-        return createItemPageResponse(itemPage, pageNo, pageSize);
+        return createItemPageResponse(itemPage);
     }
 
     @Override
@@ -142,7 +136,7 @@ public class ItemAdminServiceImpl implements ItemAdminService {
 
     @Override
     @Transactional
-    public void delete(Long id)  {
+    public void delete(Long id) {
         Item item = itemRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(ITEM_NOT_FOUND.getMessage() + id));
 
@@ -156,12 +150,11 @@ public class ItemAdminServiceImpl implements ItemAdminService {
         itemRepository.deleteById(id);
     }
 
-    private ItemPageResponse createItemPageResponse(Page<Item> itemPage, int pageNo, int pageSize) {
+    private ItemPageResponse createItemPageResponse(Page<Item> itemPage) {
         List<ItemResponse> itemResponses = itemPage.getContent().stream()
                 .map(ItemResponse::of)
                 .toList();
-        return ItemPageResponse.of(itemResponses, pageNo, pageSize, itemPage.getTotalElements(),
-                itemPage.getTotalPages(), itemPage.isLast());
+        return ItemPageResponse.of(itemResponses, itemPage);
     }
 
 }

--- a/src/main/java/com/thekey/stylekeyserver/item/service/ItemAdminServiceImpl.java
+++ b/src/main/java/com/thekey/stylekeyserver/item/service/ItemAdminServiceImpl.java
@@ -83,11 +83,7 @@ public class ItemAdminServiceImpl implements ItemAdminService {
         Pageable pageable = PageRequest.of(pageNo - 1, pageSize, Sort.by("id").descending());
         Page<Item> itemPage = itemRepository.findAll(pageable);
 
-        List<ItemResponse> itemResponses = itemPage.getContent().stream()
-                .map(ItemResponse::of)
-                .toList();
-        return ItemPageResponse.of(itemResponses, pageNo, pageSize, itemPage.getTotalElements(),
-                itemPage.getTotalPages(), itemPage.isLast());
+        return createItemPageResponse(itemPage, pageNo, pageSize);
     }
 
     @Override
@@ -104,11 +100,7 @@ public class ItemAdminServiceImpl implements ItemAdminService {
         CoordinateLook coordinateLook = coordinateLookAdminService.findById(coordinateLookId);
         Page<Item> itemPage = itemRepository.findItemByCoordinateLook(coordinateLook, pageable);
 
-        List<ItemResponse> itemResponses = itemPage.getContent().stream()
-                .map(ItemResponse::of)
-                .toList();
-        return ItemPageResponse.of(itemResponses, pageNo, pageSize, itemPage.getTotalElements(),
-                itemPage.getTotalPages(), itemPage.isLast());
+        return createItemPageResponse(itemPage, pageNo, pageSize);
     }
 
     @Override
@@ -162,6 +154,14 @@ public class ItemAdminServiceImpl implements ItemAdminService {
             imageService.deleteUnusedImages();
         }
         itemRepository.deleteById(id);
+    }
+
+    private ItemPageResponse createItemPageResponse(Page<Item> itemPage, int pageNo, int pageSize) {
+        List<ItemResponse> itemResponses = itemPage.getContent().stream()
+                .map(ItemResponse::of)
+                .toList();
+        return ItemPageResponse.of(itemResponses, pageNo, pageSize, itemPage.getTotalElements(),
+                itemPage.getTotalPages(), itemPage.isLast());
     }
 
 }


### PR DESCRIPTION
## 👊🏻 작업 내용

- 관리자페이지 내에서 데이터 전체 조회 시 페이지 번호와 사이즈 정보를 받아와 적절한 반환 데이터를 조회하도록 기능을 추가했습니다.

## 🧘🏻 기타 사항
- TODO: 서비스페이지는 데이터를 무한 스크롤 방식으로 조회해야하기 때문에 Slice를 사용하여 구현 할 예정입니다.

close #88 