### PR TITLE
fix: redis 연결 정보 수정

### DIFF
--- a/src/main/java/com/thekey/stylekeyserver/common/redis/RedisConfig.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/redis/RedisConfig.java
@@ -14,10 +14,10 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @EnableRedisRepositories
 public class RedisConfig {
 
-    @Value("${spring.redis.host}")
+    @Value("${spring.data.redis.host}")
     private String redisHost;
 
-    @Value("${spring.redis.port}")
+    @Value("${spring.data.redis.port}")
     private int redisPort;
 
     @Bean


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] redis 연결 정보 수정

## 🧘🏻 기타 사항
- EC2 안에서 Redis 연결 오류 문제 발생
- `org.springframework.data.redis.RedisConnectionFailureException: Unable to connect to Redis`
- 서버 재실행 시 Redis와 DB의 동기화 처리를 해준 코드를 머지했을 때 문제가 발생하여, 연결 정보 수정으로 해결 시도
