### PR TITLE
fix: CacheInitializer 초기화 순서 설정

### DIFF
--- a/src/main/java/com/thekey/stylekeyserver/common/cache/CacheInitializer.java
+++ b/src/main/java/com/thekey/stylekeyserver/common/cache/CacheInitializer.java
@@ -8,21 +8,46 @@ import com.thekey.stylekeyserver.like.service.LikeCoordinateLookService;
 import com.thekey.stylekeyserver.like.service.LikeItemService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.ContextRefreshedEvent;
-import org.springframework.context.event.EventListener;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class CacheInitializer {
+public class CacheInitializer implements SmartLifecycle {
 
     private final CoordinateLookRepository coordinateLookRepository;
     private final ItemRepository itemRepository;
     private final LikeItemService likeItemService;
     private final LikeCoordinateLookService likeCoordinateLookService;
 
-    @EventListener(ContextRefreshedEvent.class)
-    public void initializeCacheWithCoordinateLookLikes(ContextRefreshedEvent event) {
+    private boolean isRunning = false;
+
+    // CacheInitializer의 초기화가 필요한 의존성이 모두 준비된 후에 실행
+    @Override
+    public void start() {
+        initializeCacheWithCoordinateLookLikes();
+        initializeCacheWithItemLikes();
+        this.isRunning = true;
+    }
+
+    @Override
+    public void stop() {
+        this.isRunning = false;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return this.isRunning;
+    }
+
+    // 컴포넌트 시작 순서를 결정
+    // Redis와 같은 의존성이 있는 컴포넌트가 먼저 시작되도록 낮은 값을 설정
+    @Override
+    public int getPhase() {
+        return Integer.MIN_VALUE + 1;
+    }
+
+    private void initializeCacheWithCoordinateLookLikes() {
         List<CoordinateLook> coordinateLooks = coordinateLookRepository.findAll();
 
         coordinateLooks.forEach(coordinateLook -> {
@@ -34,8 +59,7 @@ public class CacheInitializer {
         });
     }
 
-    @EventListener(ContextRefreshedEvent.class)
-    public void initializeCacheWithItemLikes(ContextRefreshedEvent event) {
+    private void initializeCacheWithItemLikes() {
         List<Item> items = itemRepository.findAll();
 
         items.forEach(item -> {
@@ -46,5 +70,4 @@ public class CacheInitializer {
             itemRepository.save(item);
         });
     }
-
 }


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] CacheInitializer가 Redis에 의존하는 컴포넌트들이 완전히 초기화된 이후에 실행되도록 순서 설정
